### PR TITLE
fix(config): correct required_status_checks context for CodeQL

### DIFF
--- a/.github/gh-sync/config.yaml
+++ b/.github/gh-sync/config.yaml
@@ -255,7 +255,7 @@ spec:
           contexts:
             - context: CI Gate
               app: github-actions
-            - context: codeql-analyze
+            - context: CodeQL
               app: github-advanced-security
         non_fast_forward: true
         deletion: true


### PR DESCRIPTION
## 概要

- `required_status_checks` のコンテキスト名を `codeql-analyze` → `CodeQL` に修正

## 背景

`codeql-analyze` は GitHub Actions が投稿するジョブ名 (app: `github-actions`) だが、
ルールセットでは `app: github-advanced-security` と組み合わせて設定されていた。
GitHub Advanced Security が投稿するチェック名は `CodeQL` であるため、
組み合わせが誤りとなり PR #5 のマージが ruleset 違反でブロックされていた。

## テスト計画

- [ ] CI 全チェックが通過することを確認
- [ ] PR マージ後にルールセット違反なく main に取り込まれることを確認