### PR TITLE
feat: upstream manifest + local overlay support

### DIFF
--- a/.ghalint.yaml
+++ b/.ghalint.yaml
@@ -1,0 +1,9 @@
+excludes:
+  # gh-sync.yaml references naa0yama/gh-sync itself (self-referential); a full
+  # commit SHA cannot be known at generation time because the release has not
+  # been cut yet. Users are expected to pin to the appropriate SHA after
+  # the first release that includes this workflow.
+  - policy_name: action_ref_should_be_full_length_commit_sha
+    workflow_file_path: .github/workflows/gh-sync.yaml
+    job_name: gh-sync-check
+    action_name: naa0yama/gh-sync

--- a/.github/workflows/gh-sync.yaml
+++ b/.github/workflows/gh-sync.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: gh-sync check
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+  schedule:
+    - cron: "0 18 * * *" # daily at 03:00 JST
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: gh-sync-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  gh-sync-check:
+    name: gh-sync-check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: naa0yama/gh-sync@v0.1.3 # zizmor: ignore[unpinned-uses]
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          upstream-manifest: naa0yama/boilerplate-rust@main:.github/gh-sync/config.yaml

--- a/.mise/tasks.toml
+++ b/.mise/tasks.toml
@@ -101,12 +101,12 @@ description = "Run all lints"
 depends = ["fmt:check", "clippy:strict", "ast-grep"]
 
 ["lint:gh"]
-description = "Lint GitHub Actions workflows"
+description = "Lint GitHub Actions workflows (includes root-level action.yml)"
 run = """
 actionlint
 ghalint run
 ghalint run-action
-zizmor --persona=pedantic .github/
+zizmor --persona=pedantic .github/ action.yml
 """
 
 [audit]

--- a/README.md
+++ b/README.md
@@ -36,6 +36,63 @@ code .
 
 3. VS Code のコマンドパレット (`Ctrl+Shift+P` / `Cmd+Shift+P`) から「Dev Containers: Reopen in Container」を選択
 
+## GitHub Action として使う
+
+`uses: naa0yama/gh-sync@<tag>` で下流リポジトリの CI に組み込めます。
+マニフェストのスキーマ検証 → リポジトリ設定のドリフト検知 → ファイルのドリフト検知を順に実行します。
+
+```yaml
+# .github/workflows/gh-sync.yaml
+name: gh-sync check
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+  schedule:
+    - cron: "0 18 * * *" # daily at 03:00 JST
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  gh-sync-check:
+    name: gh-sync-check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@<sha> # vX.Y.Z
+        with:
+          persist-credentials: false
+      - uses: naa0yama/gh-sync@v0.1.3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+`gh-sync init --with-workflow` を実行すると、このワークフロー雛形を `.github/workflows/gh-sync.yaml` として自動生成できます。
+
+マニフェストを upstream リポジトリから取得して使う場合は `upstream-manifest` を指定します。
+ローカルの `manifest` ファイルが存在すれば、同じ `path` のルールで local が上書き (local overlay) されます。
+
+```yaml
+- uses: naa0yama/gh-sync@v0.1.3
+  with:
+    token: ${{ secrets.GITHUB_TOKEN }}
+    upstream-manifest: naa0yama/boilerplate-rust@main:.github/gh-sync/config.yaml
+    # manifest: .github/gh-sync/config.yaml  # local overlay (省略可)
+```
+
+### inputs
+
+| name                | required | default                       | 説明                                                                         |
+| ------------------- | :------: | ----------------------------- | ---------------------------------------------------------------------------- |
+| `token`             |   yes    | —                             | `gh` CLI 用トークン。`${{ secrets.GITHUB_TOKEN }}` を推奨                    |
+| `version`           |    no    | `github.action_ref`           | ダウンロードするリリースタグ。SHA pin の場合は明示指定が必要                 |
+| `manifest`          |    no    | `.github/gh-sync/config.yaml` | 同期設定ファイルのパス                                                       |
+| `upstream-manifest` |    no    | —                             | upstream マニフェスト参照。`owner/repo@ref:path` 形式。local との merge も可 |
+
 ## 使い方
 
 すべてのタスクは `mise run <task>` で実行します。
@@ -131,6 +188,7 @@ mise run pre-commit       # clean:sweep + fmt:check + clippy:strict + ast-grep +
 ├── .gitignore                  # Git 除外設定
 ├── .octocov.yml                # カバレッジレポート設定
 ├── .tagpr                      # タグ & リリース設定
+├── action.yml                  # GitHub Action 定義 (naa0yama/gh-sync として利用可)
 ├── Cargo.lock                  # 依存関係のロックファイル
 ├── Cargo.toml                  # ワークスペース設定と共有依存関係
 ├── deny.toml                   # cargo-deny 設定

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,141 @@
+# yaml-language-server: $schema=https://www.schemastore.org/github-action.json
+name: gh-sync
+description: Template sync CLI for pulling upstream files into downstream repos
+author: naa0yama
+branding:
+  icon: refresh-cw
+  color: blue
+
+inputs:
+  version:
+    description: >
+      Release tag to download (e.g. v0.1.0).
+      Defaults to the ref used in the uses: line (github.action_ref).
+      When pinning with a commit SHA, pass the corresponding release tag explicitly.
+    required: false
+    default: ${{ github.action_ref }}
+  manifest:
+    description: Path to the gh-sync manifest file
+    required: false
+    default: .github/gh-sync/config.yaml
+  upstream-manifest:
+    description: >
+      Upstream manifest reference in owner/repo@ref:path format.
+      When set, the manifest is fetched from the upstream repo and merged
+      with the local manifest (if present).
+    required: false
+  token:
+    description: >
+      GitHub token for gh release download and for the gh CLI inside gh-sync.
+      Pass ${{ secrets.GITHUB_TOKEN }} or a PAT with repo read scope.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve target triple
+      id: target
+      shell: bash
+      run: |
+        set -euo pipefail
+        case "${RUNNER_OS}/${RUNNER_ARCH}" in
+          Linux/X64)   TRIPLE="x86_64-unknown-linux-gnu"  ;;
+          Linux/ARM64) TRIPLE="aarch64-unknown-linux-gnu" ;;
+          macOS/ARM64) TRIPLE="aarch64-apple-darwin"      ;;
+          macOS/X64)   TRIPLE="x86_64-apple-darwin"       ;;
+          Windows/X64) TRIPLE="x86_64-pc-windows-msvc"    ;;
+          *)
+            echo "::error::Unsupported runner: ${RUNNER_OS}/${RUNNER_ARCH}"
+            exit 1
+            ;;
+        esac
+        echo "triple=${TRIPLE}" >> "$GITHUB_OUTPUT"
+
+    - name: Download gh-sync binary
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        VERSION: ${{ inputs.version }}
+        TRIPLE: ${{ steps.target.outputs.triple }}
+      run: |
+        set -euo pipefail
+        DEST="${RUNNER_TEMP}/gh-sync"
+        mkdir -p "${DEST}"
+
+        if [[ "${RUNNER_OS}" == "Windows" ]]; then
+          ASSET="gh-sync-${VERSION}-${TRIPLE}.zip"
+        else
+          ASSET="gh-sync-${VERSION}-${TRIPLE}.tar.gz"
+        fi
+
+        gh release download "${VERSION}" \
+          --repo naa0yama/gh-sync \
+          --pattern "${ASSET}" \
+          --pattern "SHA256SUMS" \
+          --dir "${DEST}"
+
+        cd "${DEST}"
+
+        # Verify checksum (sha256sum on Linux, shasum on macOS)
+        if command -v sha256sum >/dev/null 2>&1; then
+          grep "${ASSET}" SHA256SUMS | sha256sum --check
+        else
+          grep "${ASSET}" SHA256SUMS | shasum -a 256 -c
+        fi
+
+        if [[ "${RUNNER_OS}" == "Windows" ]]; then
+          unzip "${ASSET}"
+        else
+          tar -xzf "${ASSET}"
+        fi
+
+        BIN_DIR="${DEST}/bin"
+        mkdir -p "${BIN_DIR}"
+        if [[ "${RUNNER_OS}" == "Windows" ]]; then
+          mv gh-sync.exe "${BIN_DIR}/"
+        else
+          mv gh-sync "${BIN_DIR}/"
+        fi
+        echo "${BIN_DIR}" >> "$GITHUB_PATH"
+
+    - name: Validate manifest
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
+        MANIFEST: ${{ inputs.manifest }}
+        UPSTREAM_MANIFEST: ${{ inputs.upstream-manifest }}
+      run: |
+        set -euo pipefail
+        ARGS=(--manifest "${MANIFEST}" --validate)
+        if [[ -n "${UPSTREAM_MANIFEST}" ]]; then
+          ARGS+=(--upstream-manifest "${UPSTREAM_MANIFEST}")
+        fi
+        gh-sync sync file "${ARGS[@]}"
+
+    - name: Drift check — repo settings
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
+        MANIFEST: ${{ inputs.manifest }}
+        UPSTREAM_MANIFEST: ${{ inputs.upstream-manifest }}
+      run: |
+        set -euo pipefail
+        ARGS=(--manifest "${MANIFEST}" --ci-check)
+        if [[ -n "${UPSTREAM_MANIFEST}" ]]; then
+          ARGS+=(--upstream-manifest "${UPSTREAM_MANIFEST}")
+        fi
+        gh-sync sync repo "${ARGS[@]}"
+
+    - name: Drift check — files
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
+        MANIFEST: ${{ inputs.manifest }}
+        UPSTREAM_MANIFEST: ${{ inputs.upstream-manifest }}
+      run: |
+        set -euo pipefail
+        ARGS=(--manifest "${MANIFEST}" --ci-check)
+        if [[ -n "${UPSTREAM_MANIFEST}" ]]; then
+          ARGS+=(--upstream-manifest "${UPSTREAM_MANIFEST}")
+        fi
+        gh-sync sync file "${ARGS[@]}"

--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,7 @@ runs:
         GH_TOKEN: ${{ inputs.token }}
         VERSION: ${{ inputs.version }}
         TRIPLE: ${{ steps.target.outputs.triple }}
-      run: |
+      run: | # zizmor: ignore[github-env] BIN_DIR derives from RUNNER_TEMP (trusted runner var)
         set -euo pipefail
         DEST="${RUNNER_TEMP}/gh-sync"
         mkdir -p "${DEST}"

--- a/crates/gh-sync-engine/src/mode/ci_check.rs
+++ b/crates/gh-sync-engine/src/mode/ci_check.rs
@@ -39,6 +39,10 @@ pub fn run(
     let mut has_error = false;
 
     for rule in &manifest.files {
+        if rule.strategy == Strategy::Ignore {
+            continue;
+        }
+
         let local_path = repo_root.join(&rule.path);
         let local_bytes: Option<Vec<u8>> = std::fs::read(&local_path).ok();
 
@@ -105,6 +109,9 @@ fn evaluate_drift(
     patch_runner: &dyn PatchRunner,
 ) -> (bool, String, String, bool) {
     match rule.strategy {
+        // `Ignore` rules are skipped by the caller before `evaluate_drift` is
+        // invoked; this arm keeps the match exhaustive.
+        Strategy::Ignore => (false, String::from("ignored"), String::new(), false),
         Strategy::Delete => {
             if local_bytes.is_some() {
                 (

--- a/crates/gh-sync-engine/src/mode/sync.rs
+++ b/crates/gh-sync-engine/src/mode/sync.rs
@@ -68,6 +68,7 @@ pub fn run(
         let local_bytes: Option<Vec<u8>> = std::fs::read(&local_path).ok();
 
         let result = match rule.strategy {
+            Strategy::Ignore => continue,
             Strategy::Delete => strategy::delete::apply(local_bytes.is_some()),
             Strategy::Replace | Strategy::CreateOnly => {
                 let source = rule.source.as_deref().unwrap_or(&rule.path);

--- a/crates/gh-sync-engine/src/mode/validate.rs
+++ b/crates/gh-sync-engine/src/mode/validate.rs
@@ -26,8 +26,24 @@ pub fn run(manifest_path: &Path, repo_root: &Path, w: &mut dyn Write) -> std::io
         }
     };
 
+    run_manifest(&m, repo_root, w)
+}
+
+/// Run manifest validation on a pre-loaded manifest and write results to `w`.
+///
+/// Same as [`run`] but accepts a [`Manifest`] reference directly. Useful when
+/// the manifest has already been fetched and merged (e.g. with
+/// `--upstream-manifest`).
+///
+/// # Errors
+/// Propagates I/O errors from `w`.
+pub fn run_manifest(
+    m: &Manifest,
+    repo_root: &Path,
+    w: &mut dyn Write,
+) -> std::io::Result<ExitCode> {
     // Stage 1 — schema validation
-    let schema_ok = match manifest::validate_schema(&m) {
+    let schema_ok = match manifest::validate_schema(m) {
         Ok(()) => {
             writeln!(w, "{}  YAML syntax valid", StatusTag::Ok.styled())?;
             writeln!(
@@ -69,7 +85,7 @@ pub fn run(manifest_path: &Path, repo_root: &Path, w: &mut dyn Write) -> std::io
     }
 
     // Stage 2 — reference validation
-    let ref_ok = match manifest::validate_references(&m, repo_root) {
+    let ref_ok = match manifest::validate_references(m, repo_root) {
         Ok(()) => true,
         Err(e) => {
             writeln!(

--- a/crates/gh-sync-manifest/src/lib.rs
+++ b/crates/gh-sync-manifest/src/lib.rs
@@ -7,6 +7,8 @@
 pub mod error;
 /// Manifest schema types, loading, and validation.
 pub mod manifest;
+/// Upstream manifest + local overlay merge logic.
+pub mod merge;
 /// Strategy outcome type.
 pub mod strategy;
 
@@ -17,4 +19,5 @@ pub use manifest::{
     Ruleset, RulesetConditions, RulesetRules, SelectedActions, Spec, StatusCheckContext, Strategy,
     Upstream, resolve_patch_path, validate_references, validate_schema,
 };
+pub use merge::merge_overlay;
 pub use strategy::StrategyResult;

--- a/crates/gh-sync-manifest/src/manifest.rs
+++ b/crates/gh-sync-manifest/src/manifest.rs
@@ -410,6 +410,12 @@ pub enum Strategy {
     Delete,
     /// Apply a unified diff patch on top of the upstream file.
     Patch,
+    /// Exclude this path from sync entirely.
+    ///
+    /// Used in a local overlay manifest to cancel an upstream rule for the
+    /// same `path`. The file is never downloaded, patched, deleted, or
+    /// checked for drift.
+    Ignore,
 }
 
 impl std::fmt::Display for Strategy {
@@ -419,6 +425,7 @@ impl std::fmt::Display for Strategy {
             Self::CreateOnly => "create_only",
             Self::Delete => "delete",
             Self::Patch => "patch",
+            Self::Ignore => "ignore",
         })
     }
 }
@@ -463,6 +470,7 @@ impl Manifest {
 ///
 /// # Errors
 /// Returns [`SyncError::Validation`] if one or more constraints are violated.
+#[allow(clippy::too_many_lines)]
 pub fn validate_schema(manifest: &Manifest) -> Result<(), SyncError> {
     let mut errors: Vec<ValidationError> = Vec::new();
 
@@ -550,6 +558,22 @@ pub fn validate_schema(manifest: &Manifest) -> Result<(), SyncError> {
                         i,
                         "patch",
                         "field not allowed for strategy 'create_only'",
+                    ));
+                }
+            }
+            Strategy::Ignore => {
+                if rule.source.is_some() {
+                    errors.push(ValidationError::rule(
+                        i,
+                        "source",
+                        "field not allowed for strategy 'ignore'",
+                    ));
+                }
+                if rule.patch.is_some() {
+                    errors.push(ValidationError::rule(
+                        i,
+                        "patch",
+                        "field not allowed for strategy 'ignore'",
                     ));
                 }
             }
@@ -1034,6 +1058,8 @@ files:
   - path: other.toml
     strategy: patch
     patch: custom/other.toml.patch
+  - path: optional.txt
+    strategy: ignore
 ",
         );
     }
@@ -1374,6 +1400,63 @@ spec:
         - 'songmu/tagpr@*'
 ",
         );
+    }
+
+    // --- Strategy::Ignore ---
+
+    #[cfg_attr(miri, ignore = "libyml ptr_offset_from UB under Miri")]
+    #[test]
+    fn test_schema_ignore_is_valid() {
+        expect_schema_ok(
+            r"
+upstream:
+  repo: owner/repo
+files:
+  - path: foo.txt
+    strategy: ignore
+",
+        );
+    }
+
+    #[cfg_attr(miri, ignore = "libyml ptr_offset_from UB under Miri")]
+    #[test]
+    fn test_schema_ignore_with_source() {
+        expect_schema_error(
+            r"
+upstream:
+  repo: owner/repo
+files:
+  - path: foo.txt
+    strategy: ignore
+    source: bar.txt
+",
+            "source",
+        );
+    }
+
+    #[cfg_attr(miri, ignore = "libyml ptr_offset_from UB under Miri")]
+    #[test]
+    fn test_schema_ignore_with_patch() {
+        expect_schema_error(
+            r"
+upstream:
+  repo: owner/repo
+files:
+  - path: foo.txt
+    strategy: ignore
+    patch: foo.patch
+",
+            "patch",
+        );
+    }
+
+    #[test]
+    fn test_strategy_display() {
+        assert_eq!(Strategy::Replace.to_string(), "replace");
+        assert_eq!(Strategy::CreateOnly.to_string(), "create_only");
+        assert_eq!(Strategy::Delete.to_string(), "delete");
+        assert_eq!(Strategy::Patch.to_string(), "patch");
+        assert_eq!(Strategy::Ignore.to_string(), "ignore");
     }
 
     #[cfg_attr(miri, ignore = "tempfile I/O not supported under Miri")]

--- a/crates/gh-sync-manifest/src/merge.rs
+++ b/crates/gh-sync-manifest/src/merge.rs
@@ -1,0 +1,347 @@
+//! Merging an upstream manifest with a local overlay.
+//!
+//! The local overlay wins on a per-field / per-path basis; entries the local
+//! manifest does not mention are inherited verbatim from upstream.
+
+use crate::manifest::{Manifest, Rule, Spec, Strategy};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Merge a local overlay manifest on top of an upstream manifest.
+///
+/// Merge rules:
+///
+/// - `upstream:` node — local replaces upstream entirely when present.
+/// - `spec:` node — field-by-field merge; local `Some` fields win.
+///   Nested option fields (`features`, `merge_strategy`, `actions`, etc.)
+///   are replaced at the node level if local defines them.
+/// - `files:` — merged by `path` key:
+///   - upstream-only entries are kept as-is.
+///   - local-only entries are appended.
+///   - entries present in both are replaced by the local rule.
+///   - a local entry with `strategy: ignore` **removes** the upstream entry
+///     (the path is dropped from the result entirely).
+///
+/// # Returns
+///
+/// Returns `upstream` unchanged when `local` is `None`.
+#[must_use]
+#[allow(clippy::module_name_repetitions)] // "merge_overlay" in module "merge" is intentional
+pub fn merge_overlay(upstream: Manifest, local: Option<Manifest>) -> Manifest {
+    let Some(local) = local else {
+        return upstream;
+    };
+
+    let merged_upstream = local.upstream;
+    let merged_spec = merge_spec(upstream.spec, local.spec);
+    let merged_files = merge_files(upstream.files, local.files);
+
+    Manifest {
+        upstream: merged_upstream,
+        spec: merged_spec,
+        files: merged_files,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn merge_spec(upstream: Option<Spec>, local: Option<Spec>) -> Option<Spec> {
+    match (upstream, local) {
+        (None, None) => None,
+        (Some(u), None) => Some(u),
+        (None, Some(l)) => Some(l),
+        (Some(u), Some(l)) => Some(Spec {
+            description: l.description.or(u.description),
+            homepage: l.homepage.or(u.homepage),
+            visibility: l.visibility.or(u.visibility),
+            archived: l.archived.or(u.archived),
+            topics: l.topics.or(u.topics),
+            features: l.features.or(u.features),
+            web_commit_signoff_required: l
+                .web_commit_signoff_required
+                .or(u.web_commit_signoff_required),
+            merge_strategy: l.merge_strategy.or(u.merge_strategy),
+            release_immutability: l.release_immutability.or(u.release_immutability),
+            label_sync: l.label_sync.or(u.label_sync),
+            labels: l.labels.or(u.labels),
+            actions: l.actions.or(u.actions),
+            rulesets: l.rulesets.or(u.rulesets),
+            branch_protection: l.branch_protection.or(u.branch_protection),
+        }),
+    }
+}
+
+/// Merge two `files:` lists by `path` key.
+///
+/// The order is: upstream rules (overridden or dropped by local), then
+/// local-only rules (not present in upstream).
+fn merge_files(upstream: Vec<Rule>, local: Vec<Rule>) -> Vec<Rule> {
+    let capacity = upstream.len().saturating_add(local.len());
+    let mut result: Vec<Rule> = Vec::with_capacity(capacity);
+
+    for up_rule in upstream {
+        // Look for a matching local rule by path.
+        if let Some(local_rule) = local.iter().find(|r| r.path == up_rule.path) {
+            // `ignore` drops the upstream entry entirely.
+            if local_rule.strategy != Strategy::Ignore {
+                result.push(Rule {
+                    path: local_rule.path.clone(),
+                    strategy: local_rule.strategy,
+                    source: local_rule.source.clone(),
+                    patch: local_rule.patch.clone(),
+                });
+            }
+        } else {
+            result.push(up_rule);
+        }
+    }
+
+    // Append local-only rules (paths not present in upstream).
+    for local_rule in local {
+        let already_seen = result.iter().any(|r| r.path == local_rule.path);
+        if !already_seen && local_rule.strategy != Strategy::Ignore {
+            result.push(local_rule);
+        }
+    }
+
+    result
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)] // test assertions on known-size vecs
+
+    use super::*;
+    use crate::manifest::{Spec, Strategy, Upstream};
+
+    fn upstream_rule(path: &str, strategy: Strategy) -> Rule {
+        Rule {
+            path: path.to_owned(),
+            strategy,
+            source: None,
+            patch: None,
+        }
+    }
+
+    fn local_rule(path: &str, strategy: Strategy) -> Rule {
+        Rule {
+            path: path.to_owned(),
+            strategy,
+            source: None,
+            patch: None,
+        }
+    }
+
+    fn make_manifest(files: Vec<Rule>) -> Manifest {
+        Manifest {
+            upstream: Upstream {
+                repo: String::from("owner/repo"),
+                ref_: String::from("main"),
+            },
+            spec: None,
+            files,
+        }
+    }
+
+    fn make_manifest_with_upstream(upstream_repo: &str, files: Vec<Rule>) -> Manifest {
+        Manifest {
+            upstream: Upstream {
+                repo: upstream_repo.to_owned(),
+                ref_: String::from("main"),
+            },
+            spec: None,
+            files,
+        }
+    }
+
+    // --- No local overlay -------------------------------------------------------
+
+    #[test]
+    fn no_local_returns_upstream_unchanged() {
+        let up = make_manifest(vec![upstream_rule("foo.txt", Strategy::Replace)]);
+        let merged = merge_overlay(up, None);
+        assert_eq!(merged.files.len(), 1);
+        assert_eq!(merged.files[0].path, "foo.txt");
+        assert_eq!(merged.upstream.repo, "owner/repo");
+    }
+
+    // --- files: merge -----------------------------------------------------------
+
+    #[test]
+    fn upstream_only_files_are_kept() {
+        let up = make_manifest(vec![upstream_rule("a.txt", Strategy::Replace)]);
+        let local = make_manifest(vec![]);
+        let merged = merge_overlay(up, Some(local));
+        assert_eq!(merged.files.len(), 1);
+        assert_eq!(merged.files[0].path, "a.txt");
+    }
+
+    #[test]
+    fn local_only_files_are_appended() {
+        let up = make_manifest(vec![]);
+        let local = make_manifest(vec![local_rule("b.txt", Strategy::CreateOnly)]);
+        let merged = merge_overlay(up, Some(local));
+        assert_eq!(merged.files.len(), 1);
+        assert_eq!(merged.files[0].path, "b.txt");
+        assert_eq!(merged.files[0].strategy, Strategy::CreateOnly);
+    }
+
+    #[test]
+    fn local_wins_on_same_path() {
+        let up = make_manifest(vec![upstream_rule("Cargo.toml", Strategy::Replace)]);
+        let local = make_manifest(vec![local_rule("Cargo.toml", Strategy::Patch)]);
+        let merged = merge_overlay(up, Some(local));
+        assert_eq!(merged.files.len(), 1);
+        assert_eq!(merged.files[0].strategy, Strategy::Patch);
+    }
+
+    #[test]
+    fn ignore_drops_upstream_entry() {
+        let up = make_manifest(vec![
+            upstream_rule("keep.txt", Strategy::Replace),
+            upstream_rule("drop.txt", Strategy::Replace),
+        ]);
+        let local = make_manifest(vec![local_rule("drop.txt", Strategy::Ignore)]);
+        let merged = merge_overlay(up, Some(local));
+        assert_eq!(merged.files.len(), 1);
+        assert_eq!(merged.files[0].path, "keep.txt");
+    }
+
+    #[test]
+    fn ignore_local_only_is_not_appended() {
+        // A local `ignore` for a path not in upstream should not appear in result.
+        let up = make_manifest(vec![upstream_rule("a.txt", Strategy::Replace)]);
+        let local = make_manifest(vec![local_rule("nonexistent.txt", Strategy::Ignore)]);
+        let merged = merge_overlay(up, Some(local));
+        assert_eq!(merged.files.len(), 1);
+        assert_eq!(merged.files[0].path, "a.txt");
+    }
+
+    #[test]
+    fn mixed_files_merge_correctly() {
+        let up = make_manifest(vec![
+            upstream_rule("a.txt", Strategy::Replace),
+            upstream_rule("b.txt", Strategy::Replace),
+            upstream_rule("c.txt", Strategy::Replace),
+        ]);
+        let local = make_manifest(vec![
+            local_rule("b.txt", Strategy::Patch),      // override
+            local_rule("c.txt", Strategy::Ignore),     // drop
+            local_rule("d.txt", Strategy::CreateOnly), // local-only
+        ]);
+        let merged = merge_overlay(up, Some(local));
+        // Result: a.txt (upstream), b.txt (local patch), d.txt (local-only)
+        assert_eq!(merged.files.len(), 3);
+        assert_eq!(merged.files[0].path, "a.txt");
+        assert_eq!(merged.files[0].strategy, Strategy::Replace);
+        assert_eq!(merged.files[1].path, "b.txt");
+        assert_eq!(merged.files[1].strategy, Strategy::Patch);
+        assert_eq!(merged.files[2].path, "d.txt");
+        assert_eq!(merged.files[2].strategy, Strategy::CreateOnly);
+    }
+
+    // --- upstream: node ---------------------------------------------------------
+
+    #[test]
+    fn local_upstream_node_replaces_upstream() {
+        let up = make_manifest_with_upstream("upstream/template", vec![]);
+        let local = make_manifest_with_upstream("local/override", vec![]);
+        let merged = merge_overlay(up, Some(local));
+        assert_eq!(merged.upstream.repo, "local/override");
+    }
+
+    // --- spec: field-wise merge -------------------------------------------------
+
+    #[test]
+    fn spec_local_wins_per_field() {
+        let mut up = make_manifest(vec![upstream_rule("f.txt", Strategy::Replace)]);
+        up.spec = Some(Spec {
+            description: Some(String::from("upstream desc")),
+            homepage: Some(String::from("https://upstream.example")),
+            visibility: Some(String::from("private")),
+            archived: None,
+            topics: None,
+            features: None,
+            web_commit_signoff_required: None,
+            merge_strategy: None,
+            release_immutability: None,
+            label_sync: None,
+            labels: None,
+            actions: None,
+            rulesets: None,
+            branch_protection: None,
+        });
+
+        let mut local = make_manifest(vec![]);
+        local.spec = Some(Spec {
+            description: Some(String::from("local desc")),
+            homepage: None,
+            visibility: None,
+            archived: Some(false),
+            topics: None,
+            features: None,
+            web_commit_signoff_required: None,
+            merge_strategy: None,
+            release_immutability: None,
+            label_sync: None,
+            labels: None,
+            actions: None,
+            rulesets: None,
+            branch_protection: None,
+        });
+
+        let merged = merge_overlay(up, Some(local));
+        let spec = merged.spec.unwrap();
+        // local description wins
+        assert_eq!(spec.description.as_deref(), Some("local desc"));
+        // upstream homepage is preserved (local had None)
+        assert_eq!(spec.homepage.as_deref(), Some("https://upstream.example"));
+        // upstream visibility preserved
+        assert_eq!(spec.visibility.as_deref(), Some("private"));
+        // local archived wins
+        assert_eq!(spec.archived, Some(false));
+    }
+
+    #[test]
+    fn spec_upstream_only_preserved() {
+        let mut up = make_manifest(vec![upstream_rule("f.txt", Strategy::Replace)]);
+        up.spec = Some(Spec {
+            description: Some(String::from("desc")),
+            homepage: None,
+            visibility: None,
+            archived: None,
+            topics: None,
+            features: None,
+            web_commit_signoff_required: None,
+            merge_strategy: None,
+            release_immutability: None,
+            label_sync: None,
+            labels: None,
+            actions: None,
+            rulesets: None,
+            branch_protection: None,
+        });
+
+        let local = make_manifest(vec![]);
+        let merged = merge_overlay(up, Some(local));
+        let spec = merged.spec.unwrap();
+        assert_eq!(spec.description.as_deref(), Some("desc"));
+    }
+
+    #[test]
+    fn spec_both_none_stays_none() {
+        let up = make_manifest(vec![upstream_rule("f.txt", Strategy::Replace)]);
+        let local = make_manifest(vec![]);
+        let merged = merge_overlay(up, Some(local));
+        assert!(merged.spec.is_none());
+    }
+}

--- a/crates/gh-sync/src/init/cli.rs
+++ b/crates/gh-sync/src/init/cli.rs
@@ -4,6 +4,8 @@ use clap::Parser;
 
 /// Arguments for the `init` subcommand.
 #[derive(Parser, Debug)]
+// Mode flags map directly to clap boolean arguments; mutual exclusion is enforced by conflicts_with.
+#[allow(clippy::struct_excessive_bools)]
 pub struct InitArgs {
     /// Upstream repository in `owner/name` format
     #[arg(short = 'r', long = "repo")]
@@ -32,4 +34,8 @@ pub struct InitArgs {
     /// Overwrite an existing config file without prompting
     #[arg(long = "force")]
     pub force: bool,
+
+    /// Also generate a GitHub Actions workflow that calls the gh-sync action
+    #[arg(long = "with-workflow")]
+    pub with_workflow: bool,
 }

--- a/crates/gh-sync/src/init/mod.rs
+++ b/crates/gh-sync/src/init/mod.rs
@@ -8,6 +8,8 @@ mod generate;
 pub mod schema;
 /// Interactive file + strategy picker widget.
 mod select;
+/// GitHub Actions workflow template generator.
+pub mod workflow;
 
 use std::io::{self, IsTerminal as _, Write as _};
 use std::path::Path;
@@ -217,6 +219,55 @@ pub fn run(
         output_dir.display()
     )
     .context("failed to write to stdout")?;
+
+    // -----------------------------------------------------------------------
+    // 6. Optionally generate the GitHub Actions workflow file
+    // -----------------------------------------------------------------------
+    let emit_workflow = if args.with_workflow {
+        true
+    } else if io::stdin().is_terminal() {
+        dialoguer::Confirm::new()
+            .with_prompt("Generate a GitHub Actions workflow (.github/workflows/gh-sync.yaml)?")
+            .default(true)
+            .interact()
+            .context("workflow prompt cancelled")?
+    } else {
+        false
+    };
+
+    if emit_workflow {
+        let workflow_path = Path::new(workflow::WORKFLOW_PATH);
+        let version = concat!("v", env!("CARGO_PKG_VERSION"));
+
+        if workflow_path.exists() && !args.force {
+            if io::stdin().is_terminal() {
+                let confirmed = dialoguer::Confirm::new()
+                    .with_prompt(format!(
+                        "'{}' already exists. Overwrite?",
+                        workflow_path.display()
+                    ))
+                    .default(false)
+                    .interact()
+                    .context("confirmation prompt cancelled")?;
+                if !confirmed {
+                    writeln!(stdout, "Skipped '{}'.", workflow_path.display())
+                        .context("failed to write to stdout")?;
+                    return Ok(());
+                }
+            } else {
+                anyhow::bail!(
+                    "'{}' already exists; use --force to overwrite",
+                    workflow_path.display()
+                );
+            }
+        }
+
+        // Always pin to `main` in the generated workflow; users can edit afterwards.
+        let upstream_manifest = format!("{repo}@main:.github/gh-sync/config.yaml");
+        workflow::write_workflow_file(workflow_path, version, Some(&upstream_manifest))?;
+        writeln!(stdout, "[OK] created '{}'", workflow_path.display())
+            .context("failed to write to stdout")?;
+    }
 
     Ok(())
 }

--- a/crates/gh-sync/src/init/select.rs
+++ b/crates/gh-sync/src/init/select.rs
@@ -176,6 +176,7 @@ const fn strategy_label(s: Strategy) -> &'static str {
         Strategy::CreateOnly => "create_only",
         Strategy::Delete => "delete     ",
         Strategy::Patch => "patch      ",
+        Strategy::Ignore => "ignore     ",
     }
 }
 

--- a/crates/gh-sync/src/init/workflow.rs
+++ b/crates/gh-sync/src/init/workflow.rs
@@ -1,0 +1,157 @@
+use std::path::Path;
+
+/// Default output path for the generated workflow file.
+pub const WORKFLOW_PATH: &str = ".github/workflows/gh-sync.yaml";
+
+/// Workflow template with `{{version}}` and `{{upstream_manifest_line}}` placeholders.
+const TEMPLATE: &str = "\
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: gh-sync check
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+  schedule:
+    - cron: \"0 18 * * *\" # daily at 03:00 JST
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: gh-sync-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  gh-sync-check:
+    name: gh-sync-check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: naa0yama/gh-sync@{{version}} # zizmor: ignore[unpinned-uses]
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+{{upstream_manifest_line}}
+";
+
+/// Render the workflow template by substituting `{{version}}` and `{{upstream_manifest_line}}`.
+///
+/// - `version`: the gh-sync release tag (e.g. `v0.1.0`).
+/// - `upstream_manifest`: when `Some`, emits an `upstream-manifest:` input line;
+///   when `None`, emits a commented-out placeholder instead.
+#[must_use]
+pub fn render(version: &str, upstream_manifest: Option<&str>) -> String {
+    let upstream_line = upstream_manifest.map_or_else(
+        || {
+            String::from(
+                "          # upstream-manifest: owner/repo@main:.github/gh-sync/config.yaml",
+            )
+        },
+        |v| format!("          upstream-manifest: {v}"),
+    );
+    TEMPLATE
+        .replace("{{version}}", version)
+        .replace("{{upstream_manifest_line}}", &upstream_line)
+}
+
+/// Write the rendered workflow file to `path`, creating parent directories as needed.
+///
+/// # Errors
+///
+/// Returns an error when the directory cannot be created or the file cannot be written.
+pub fn write_workflow_file(
+    path: &Path,
+    version: &str,
+    upstream_manifest: Option<&str>,
+) -> anyhow::Result<()> {
+    use anyhow::Context as _;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create directory '{}'", parent.display()))?;
+    }
+    std::fs::write(path, render(version, upstream_manifest))
+        .with_context(|| format!("failed to write workflow file '{}'", path.display()))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[test]
+    fn render_substitutes_version() {
+        let out = render("v1.2.3", None);
+        assert!(out.contains("naa0yama/gh-sync@v1.2.3"));
+        assert!(!out.contains("{{version}}"));
+    }
+
+    #[test]
+    fn render_contains_required_fields() {
+        let out = render("v0.1.0", None);
+        assert!(out.contains("gh-sync check"));
+        assert!(out.contains("actions/checkout@"));
+        assert!(out.contains("secrets.GITHUB_TOKEN"));
+        assert!(out.contains("contents: read"));
+    }
+
+    #[test]
+    fn render_with_upstream_manifest_emits_active_line() {
+        let out = render(
+            "v0.1.0",
+            Some("owner/repo@main:.github/gh-sync/config.yaml"),
+        );
+        assert!(
+            out.contains("upstream-manifest: owner/repo@main:.github/gh-sync/config.yaml"),
+            "missing upstream-manifest line: {out}"
+        );
+        assert!(
+            !out.contains("{{upstream_manifest_line}}"),
+            "placeholder not replaced: {out}"
+        );
+    }
+
+    #[test]
+    fn render_without_upstream_manifest_emits_comment() {
+        let out = render("v0.1.0", None);
+        assert!(
+            out.contains("# upstream-manifest: owner/repo@main:.github/gh-sync/config.yaml"),
+            "missing comment placeholder: {out}"
+        );
+        assert!(
+            !out.contains("{{upstream_manifest_line}}"),
+            "placeholder not replaced: {out}"
+        );
+    }
+
+    #[test]
+    fn write_workflow_file_creates_file_and_dirs() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join(".github/workflows/gh-sync.yaml");
+        write_workflow_file(&path, "v0.1.0", None).unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("naa0yama/gh-sync@v0.1.0"));
+    }
+
+    #[test]
+    fn write_workflow_file_overwrites_existing() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("gh-sync.yaml");
+        std::fs::write(&path, b"old content").unwrap();
+        write_workflow_file(&path, "v0.2.0", None).unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("v0.2.0"));
+        assert!(!content.contains("old content"));
+    }
+}

--- a/crates/gh-sync/src/sync/cli.rs
+++ b/crates/gh-sync/src/sync/cli.rs
@@ -24,13 +24,23 @@ pub enum SyncCommand {
 // and mutual exclusion is enforced by `conflicts_with_all`.
 #[allow(clippy::struct_excessive_bools)]
 pub struct SyncFileArgs {
-    /// Path to the gh-sync manifest file
+    /// Path to the local gh-sync manifest file (used as overlay when
+    /// --upstream-manifest is also given; may be absent in that case)
     #[arg(
         short = 'm',
         long = "manifest",
         default_value = ".github/gh-sync/config.yaml"
     )]
     pub manifest: PathBuf,
+
+    /// Upstream manifest reference in `owner/repo@ref:path` format.
+    ///
+    /// When given the manifest is fetched from the upstream repository and
+    /// merged with the local manifest (local wins on conflicting paths).
+    /// If the local manifest file does not exist only the upstream manifest
+    /// is used.
+    #[arg(long = "upstream-manifest", value_name = "OWNER/REPO@REF:PATH")]
+    pub upstream_manifest: Option<String>,
 
     /// Show what would change without writing any files
     #[arg(short = 'n', long = "dry-run")]
@@ -57,13 +67,23 @@ pub struct SyncFileArgs {
 #[derive(Parser, Debug)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct SyncRepoArgs {
-    /// Path to the gh-sync manifest file
+    /// Path to the local gh-sync manifest file (used as overlay when
+    /// --upstream-manifest is also given; may be absent in that case)
     #[arg(
         short = 'm',
         long = "manifest",
         default_value = ".github/gh-sync/config.yaml"
     )]
     pub manifest: PathBuf,
+
+    /// Upstream manifest reference in `owner/repo@ref:path` format.
+    ///
+    /// When given the manifest is fetched from the upstream repository and
+    /// merged with the local manifest (local wins on conflicting paths).
+    /// If the local manifest file does not exist only the upstream manifest
+    /// is used.
+    #[arg(long = "upstream-manifest", value_name = "OWNER/REPO@REF:PATH")]
+    pub upstream_manifest: Option<String>,
 
     /// Show what would change without applying
     #[arg(short = 'n', long = "dry-run")]

--- a/crates/gh-sync/src/sync/mod.rs
+++ b/crates/gh-sync/src/sync/mod.rs
@@ -18,6 +18,8 @@ pub mod runner;
 pub mod strategy;
 /// Upstream file fetching via the `gh` CLI
 pub mod upstream;
+/// Parsing and fetching of `--upstream-manifest` references
+pub mod upstream_manifest;
 
 use std::io::{self, IsTerminal as _};
 use std::process::ExitCode;
@@ -48,7 +50,8 @@ fn execute_file(args: &cli::SyncFileArgs) -> ExitCode {
         .and_then(|p| p.parent())
         .unwrap_or_else(|| std::path::Path::new("."));
 
-    if args.validate {
+    // --validate without --upstream-manifest: use the fast file-based path.
+    if args.validate && args.upstream_manifest.is_none() {
         return match mode::validate::run(&args.manifest, repo_root, &mut stdout) {
             Ok(code) => code,
             Err(e) => {
@@ -58,22 +61,38 @@ fn execute_file(args: &cli::SyncFileArgs) -> ExitCode {
         };
     }
 
-    // Load and validate the manifest for all non-validate modes.
-    let manifest = match manifest::Manifest::load(&args.manifest) {
+    // Resolve the effective manifest (upstream fetch + optional local overlay,
+    // or just local file when --upstream-manifest is not given).
+    let fetcher = GhFetcher;
+    let manifest = match upstream_manifest::resolve(
+        args.upstream_manifest.as_deref(),
+        &args.manifest,
+        &fetcher,
+    ) {
         Ok(m) => m,
         Err(e) => {
-            tracing::error!("failed to load manifest: {e}");
+            tracing::error!("failed to resolve manifest: {e:#}");
             tracing::info!("hint: run `gh-sync init` to create a configuration file");
             return ExitCode::FAILURE;
         }
     };
+
+    // --validate with --upstream-manifest: validate the merged manifest.
+    if args.validate {
+        return match mode::validate::run_manifest(&manifest, repo_root, &mut stdout) {
+            Ok(code) => code,
+            Err(e) => {
+                tracing::error!("sync file --validate I/O error: {e}");
+                ExitCode::FAILURE
+            }
+        };
+    }
 
     if let Err(e) = manifest::validate_schema(&manifest) {
         tracing::error!("manifest validation failed: {e}");
         return ExitCode::FAILURE;
     }
 
-    let fetcher = GhFetcher;
     let patch_runner = RealPatchRunner;
 
     if args.ci_check {

--- a/crates/gh-sync/src/sync/mode/validate.rs
+++ b/crates/gh-sync/src/sync/mode/validate.rs
@@ -1,3 +1,2 @@
 //! Re-export `validate` mode from `gh-sync-engine`.
-#![allow(unused_imports)]
-pub use gh_sync_engine::mode::validate::run;
+pub use gh_sync_engine::mode::validate::{run, run_manifest};

--- a/crates/gh-sync/src/sync/repo.rs
+++ b/crates/gh-sync/src/sync/repo.rs
@@ -15,10 +15,12 @@ pub use gh_sync_engine::repo::{
     SelectedActionsApi, SpecChange, WorkflowPermissionsApi, apply_changes, compare,
     parse_branch_protection_api, parse_repo_api_data, print_preview,
 };
-use gh_sync_manifest::{Manifest, Spec};
+use gh_sync_manifest::Spec;
 
 use crate::sync::manifest;
 use crate::sync::runner::{GhRunner, SystemGhRunner};
+use crate::sync::upstream::GhFetcher;
+use crate::sync::upstream_manifest;
 
 // ---------------------------------------------------------------------------
 // Production GhRepoClient
@@ -598,22 +600,31 @@ fn execute_inner(
     client: &dyn GhRepoClient,
     w: &mut dyn Write,
 ) -> ExitCode {
-    let manifest = match Manifest::load(&args.manifest) {
-        Ok(m) => m,
-        Err(e) => {
-            tracing::error!("failed to load manifest: {e}");
-            return ExitCode::FAILURE;
-        }
-    };
-
-    // Validate schema and local references before making any API calls.
-    // A misconfigured manifest must be caught early to prevent partial apply.
+    // Resolve the directory containing the manifest as the repo root.
     let repo_root = args
         .manifest
         .parent()
         .and_then(|p| p.parent())
         .and_then(|p| p.parent())
         .unwrap_or_else(|| std::path::Path::new("."));
+
+    // Resolve the effective manifest (upstream fetch + optional local overlay,
+    // or just local file when --upstream-manifest is not given).
+    let fetcher = GhFetcher;
+    let manifest = match upstream_manifest::resolve(
+        args.upstream_manifest.as_deref(),
+        &args.manifest,
+        &fetcher,
+    ) {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::error!("failed to resolve manifest: {e:#}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    // Validate schema and local references before making any API calls.
+    // A misconfigured manifest must be caught early to prevent partial apply.
     if let Err(e) = manifest::validate_schema(&manifest) {
         tracing::error!("manifest validation failed: {e}");
         return ExitCode::FAILURE;
@@ -1886,6 +1897,7 @@ mod tests {
         .unwrap();
         let args = super::super::cli::SyncRepoArgs {
             manifest: path,
+            upstream_manifest: None,
             dry_run: false,
             ci_check: false,
             yes: false,
@@ -1913,6 +1925,7 @@ mod tests {
         .unwrap();
         let args = super::super::cli::SyncRepoArgs {
             manifest: path,
+            upstream_manifest: None,
             dry_run: false,
             ci_check: false,
             yes: false,
@@ -1937,6 +1950,7 @@ mod tests {
         .unwrap();
         let args = super::super::cli::SyncRepoArgs {
             manifest: path,
+            upstream_manifest: None,
             dry_run: false,
             ci_check: true,
             yes: false,
@@ -1959,6 +1973,7 @@ mod tests {
         .unwrap();
         let args = super::super::cli::SyncRepoArgs {
             manifest: path,
+            upstream_manifest: None,
             dry_run: true,
             ci_check: false,
             yes: false,

--- a/crates/gh-sync/src/sync/upstream_manifest.rs
+++ b/crates/gh-sync/src/sync/upstream_manifest.rs
@@ -1,0 +1,307 @@
+//! Parsing and fetching of `--upstream-manifest` references.
+//!
+//! The reference format is `owner/repo@ref:path`, where `@ref` may be omitted
+//! (defaults to `"HEAD"`) but `:path` is always required.
+
+use anyhow::Context as _;
+use gh_sync_manifest::{Manifest, merge_overlay};
+
+use crate::sync::upstream::UpstreamFetcher;
+
+// ---------------------------------------------------------------------------
+// Reference type
+// ---------------------------------------------------------------------------
+
+/// A parsed `--upstream-manifest` value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(clippy::module_name_repetitions)]
+pub struct UpstreamManifestRef {
+    /// `owner/name` repository.
+    pub repo: String,
+    /// Git ref (branch, tag, or commit SHA). Defaults to `"HEAD"`.
+    pub ref_: String,
+    /// Path to the manifest YAML inside the repository.
+    pub path: String,
+}
+
+impl UpstreamManifestRef {
+    /// Parse `owner/repo@ref:path` or `owner/repo:path` (ref defaults to `"HEAD"`).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the format is invalid.
+    pub fn parse(s: &str) -> anyhow::Result<Self> {
+        // Split on the last `:` to get the path.
+        let Some((repo_and_ref, path)) = s.rsplit_once(':') else {
+            anyhow::bail!(
+                "invalid upstream-manifest '{s}': missing ':path' \
+                 (expected owner/repo@ref:path)"
+            );
+        };
+
+        if path.is_empty() {
+            anyhow::bail!(
+                "invalid upstream-manifest '{s}': path must not be empty \
+                 (expected owner/repo@ref:path)"
+            );
+        }
+
+        // Split on `@` to separate the repo from the ref.
+        let (repo, ref_) = if let Some((r, rf)) = repo_and_ref.split_once('@') {
+            if rf.is_empty() {
+                anyhow::bail!("invalid upstream-manifest '{s}': ref after '@' must not be empty");
+            }
+            (r.to_owned(), rf.to_owned())
+        } else {
+            (repo_and_ref.to_owned(), String::from("HEAD"))
+        };
+
+        // Validate owner/name format (same rule as manifest upstream.repo).
+        if !is_valid_repo(&repo) {
+            anyhow::bail!(
+                "invalid upstream-manifest '{s}': repository '{repo}' must be \
+                 owner/name format (e.g. naa0yama/boilerplate-rust)"
+            );
+        }
+
+        Ok(Self {
+            repo,
+            ref_,
+            path: path.to_owned(),
+        })
+    }
+}
+
+/// Return `true` when `repo` matches the `owner/name` pattern.
+fn is_valid_repo(repo: &str) -> bool {
+    let Some((owner, name)) = repo.split_once('/') else {
+        return false;
+    };
+    if name.contains('/') {
+        return false;
+    }
+    let valid_segment = |s: &str| {
+        !s.is_empty()
+            && s.chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-')
+    };
+    valid_segment(owner) && valid_segment(name)
+}
+
+// ---------------------------------------------------------------------------
+// Fetch + merge
+// ---------------------------------------------------------------------------
+
+/// Fetch the upstream manifest and merge it with an optional local manifest.
+///
+/// Steps:
+/// 1. Fetch `ref.path` from `ref.repo@ref.ref_` via `fetcher`.
+/// 2. Parse the fetched YAML as a [`Manifest`].
+/// 3. Call [`merge_overlay`] with `upstream` and `local`.
+///
+/// # Errors
+///
+/// Returns an error when:
+/// - The fetch fails or returns `NotFound`.
+/// - The fetched content cannot be parsed as a valid manifest YAML.
+pub fn fetch_and_merge(
+    ref_: &UpstreamManifestRef,
+    fetcher: &dyn UpstreamFetcher,
+    local: Option<Manifest>,
+) -> anyhow::Result<Manifest> {
+    use gh_sync_engine::upstream::FetchResult;
+
+    let bytes = match fetcher
+        .fetch(&ref_.repo, &ref_.ref_, &ref_.path)
+        .with_context(|| {
+            format!(
+                "failed to fetch upstream manifest '{}@{}:{}'",
+                ref_.repo, ref_.ref_, ref_.path
+            )
+        })? {
+        FetchResult::Content(b) => b,
+        FetchResult::NotFound => {
+            anyhow::bail!(
+                "upstream manifest not found: '{}@{}:{}'",
+                ref_.repo,
+                ref_.ref_,
+                ref_.path
+            );
+        }
+    };
+
+    let yaml = String::from_utf8(bytes).with_context(|| {
+        format!(
+            "upstream manifest '{}@{}:{}' is not valid UTF-8",
+            ref_.repo, ref_.ref_, ref_.path
+        )
+    })?;
+
+    let upstream: Manifest = serde_yml::from_str(&yaml).with_context(|| {
+        format!(
+            "failed to parse upstream manifest '{}@{}:{}'",
+            ref_.repo, ref_.ref_, ref_.path
+        )
+    })?;
+
+    Ok(merge_overlay(upstream, local))
+}
+
+// ---------------------------------------------------------------------------
+// Convenience resolver
+// ---------------------------------------------------------------------------
+
+/// Resolve the effective manifest for a sync command.
+///
+/// - When `upstream_ref_str` is `Some`: parse and fetch the upstream manifest,
+///   then merge with the local manifest (if the local file exists at
+///   `local_path`).
+/// - When `upstream_ref_str` is `None`: load the manifest from `local_path`
+///   (must exist).
+///
+/// # Errors
+///
+/// Returns an error when:
+/// - `upstream_ref_str` cannot be parsed.
+/// - The upstream manifest cannot be fetched or parsed.
+/// - `upstream_ref_str` is `None` and `local_path` cannot be read.
+#[cfg_attr(coverage_nightly, coverage(off))]
+pub fn resolve(
+    upstream_ref_str: Option<&str>,
+    local_path: &std::path::Path,
+    fetcher: &dyn UpstreamFetcher,
+) -> anyhow::Result<Manifest> {
+    if let Some(ref_str) = upstream_ref_str {
+        let ref_ = UpstreamManifestRef::parse(ref_str)
+            .with_context(|| format!("failed to parse upstream-manifest '{ref_str}'"))?;
+
+        // Load the local manifest as an optional overlay.
+        let local = if local_path.exists() {
+            Some(Manifest::load(local_path).with_context(|| {
+                format!("failed to load local manifest '{}'", local_path.display())
+            })?)
+        } else {
+            None
+        };
+
+        fetch_and_merge(&ref_, fetcher, local)
+    } else {
+        Manifest::load(local_path)
+            .with_context(|| format!("failed to load manifest '{}'", local_path.display()))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
+
+    use super::*;
+
+    // --- UpstreamManifestRef::parse ------------------------------------------
+
+    #[test]
+    fn parse_full_form() {
+        let r = UpstreamManifestRef::parse(
+            "naa0yama/boilerplate-rust@main:.github/gh-sync/config.yaml",
+        )
+        .unwrap();
+        assert_eq!(r.repo, "naa0yama/boilerplate-rust");
+        assert_eq!(r.ref_, "main");
+        assert_eq!(r.path, ".github/gh-sync/config.yaml");
+    }
+
+    #[test]
+    fn parse_without_ref_defaults_to_head() {
+        let r = UpstreamManifestRef::parse("owner/repo:config.yaml").unwrap();
+        assert_eq!(r.repo, "owner/repo");
+        assert_eq!(r.ref_, "HEAD");
+        assert_eq!(r.path, "config.yaml");
+    }
+
+    #[test]
+    fn parse_nested_path() {
+        let r =
+            UpstreamManifestRef::parse("owner/repo@v1.0.0:.github/gh-sync/config.yaml").unwrap();
+        assert_eq!(r.ref_, "v1.0.0");
+        assert_eq!(r.path, ".github/gh-sync/config.yaml");
+    }
+
+    #[test]
+    fn parse_missing_path_separator_errors() {
+        assert!(UpstreamManifestRef::parse("owner/repo@main").is_err());
+    }
+
+    #[test]
+    fn parse_empty_path_errors() {
+        assert!(UpstreamManifestRef::parse("owner/repo@main:").is_err());
+    }
+
+    #[test]
+    fn parse_empty_ref_errors() {
+        assert!(UpstreamManifestRef::parse("owner/repo@:path").is_err());
+    }
+
+    #[test]
+    fn parse_invalid_repo_format_errors() {
+        assert!(UpstreamManifestRef::parse("notarepo@main:path").is_err());
+    }
+
+    #[test]
+    fn parse_repo_with_double_slash_errors() {
+        assert!(UpstreamManifestRef::parse("a/b/c@main:path").is_err());
+    }
+
+    // --- fetch_and_merge --------------------------------------------------
+
+    #[test]
+    fn fetch_and_merge_no_local() {
+        use gh_sync_engine::upstream::testing::MockFetcher;
+
+        let yaml =
+            b"upstream:\n  repo: owner/repo\nfiles:\n  - path: foo.txt\n    strategy: replace\n"
+                .to_vec();
+        let fetcher = MockFetcher::content(yaml);
+        let ref_ = UpstreamManifestRef {
+            repo: String::from("owner/repo"),
+            ref_: String::from("main"),
+            path: String::from("config.yaml"),
+        };
+
+        let m = fetch_and_merge(&ref_, &fetcher, None).unwrap();
+        assert_eq!(m.files.len(), 1);
+        assert_eq!(m.files[0].path, "foo.txt");
+    }
+
+    #[test]
+    fn fetch_not_found_returns_error() {
+        use gh_sync_engine::upstream::testing::MockFetcher;
+
+        let fetcher = MockFetcher::not_found();
+        let ref_ = UpstreamManifestRef {
+            repo: String::from("owner/repo"),
+            ref_: String::from("main"),
+            path: String::from("config.yaml"),
+        };
+
+        assert!(fetch_and_merge(&ref_, &fetcher, None).is_err());
+    }
+
+    #[test]
+    fn fetch_error_propagates() {
+        use gh_sync_engine::upstream::testing::MockFetcher;
+
+        let fetcher = MockFetcher::error("network down");
+        let ref_ = UpstreamManifestRef {
+            repo: String::from("owner/repo"),
+            ref_: String::from("main"),
+            path: String::from("config.yaml"),
+        };
+
+        assert!(fetch_and_merge(&ref_, &fetcher, None).is_err());
+    }
+}

--- a/crates/gh-sync/tests/integration_test.rs
+++ b/crates/gh-sync/tests/integration_test.rs
@@ -146,6 +146,17 @@ fn test_cli_from_upstream_and_select_conflict() {
 
 #[test]
 #[cfg_attr(miri, ignore)]
+fn test_cli_init_with_workflow_in_help() {
+    // --with-workflow flag must appear in init --help
+    let mut cmd = cargo_bin_cmd!("gh-sync");
+    cmd.args(["init", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("with-workflow"));
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
 fn test_cli_validate_missing_manifest() {
     // Validation with a non-existent manifest returns failure
     let mut cmd = cargo_bin_cmd!("gh-sync");

--- a/docs/specs/template-sync.ja.md
+++ b/docs/specs/template-sync.ja.md
@@ -723,14 +723,15 @@ commit / PR 操作はこのコマンドでは行わない — skill 経由で Cl
 
 ### 5.4 `gh-sync init` フラグ
 
-| フラグ            | 短縮 | 型   | デフォルト                    | 説明                                            |
-| ----------------- | ---- | ---- | ----------------------------- | ----------------------------------------------- |
-| `--repo`          | `-r` | str  | —(TTY の場合はプロンプト)     | upstream リポジトリ(`owner/name` 形式)          |
-| `--ref`           |      | str  | `main`                        | 取得元の git ref                                |
-| `--output`        | `-o` | Path | `.github/gh-sync/config.yaml` | 出力先パス                                      |
-| `--from-upstream` |      | bool | false                         | upstream 自身の config をコピー(非対話モード可) |
-| `--select`        |      | bool | false                         | upstream のファイル一覧から対話的に選択         |
-| `--force`         |      | bool | false                         | 既存ファイルを確認なしで上書き                  |
+| フラグ            | 短縮 | 型   | デフォルト                    | 説明                                                       |
+| ----------------- | ---- | ---- | ----------------------------- | ---------------------------------------------------------- |
+| `--repo`          | `-r` | str  | —(TTY の場合はプロンプト)     | upstream リポジトリ(`owner/name` 形式)                     |
+| `--ref`           |      | str  | `main`                        | 取得元の git ref                                           |
+| `--output`        | `-o` | Path | `.github/gh-sync/config.yaml` | 出力先パス                                                 |
+| `--from-upstream` |      | bool | false                         | upstream 自身の config をコピー(非対話モード可)            |
+| `--select`        |      | bool | false                         | upstream のファイル一覧から対話的に選択                    |
+| `--with-workflow` |      | bool | false                         | `.github/workflows/gh-sync.yaml` を同時生成 (詳細は §11.3) |
+| `--force`         |      | bool | false                         | 既存ファイルを確認なしで上書き                             |
 
 `--from-upstream` と `--select` は相互排他。どちらも指定しない場合、TTY であればモード選択プロンプトを表示する。
 
@@ -948,3 +949,190 @@ Run `gh-sync sync` locally to apply upstream changes.
 
 5. **`--patch-refresh` でローカルファイル不在**: upstream との完全差分を patch として生成。
    `strategy: patch` を明示しているのに patch ファイルがないのは作成漏れ。生成して確認・編集できる状態にするのが親切。
+
+---
+
+## 11. GitHub Action
+
+### 11.1 使い方
+
+`action.yml` をリポジトリ直下に配置することで、下流リポジトリから
+`uses: naa0yama/gh-sync@<tag>` の形式で呼び出せる公開 Action として機能する。
+
+実行シーケンス (固定・書き込みなし):
+
+1. `gh-sync sync file --validate` — マニフェストのスキーマ検証 (ローカル、upstream 接続なし)
+2. `gh-sync sync repo --ci-check` — リポジトリ設定のドリフト検知
+3. `gh-sync sync file --ci-check` — ファイルのドリフト検知
+
+いずれかのステップが失敗すると Action は即時 exit 1 する (GitHub Actions のデフォルト fail-fast)。
+ドリフトを **取り込む** 責務は持たず、検知のみ。
+
+### 11.2 inputs
+
+| name                | required | default                       | 説明                                                                       |
+| ------------------- | :------: | ----------------------------- | -------------------------------------------------------------------------- |
+| `token`             |   yes    | —                             | `gh release download` と `gh` CLI 内部で使用するトークン                   |
+| `version`           |    no    | `github.action_ref`           | ダウンロードするリリースタグ (例: `v0.1.3`)。SHA pin 時は明示必須          |
+| `manifest`          |    no    | `.github/gh-sync/config.yaml` | 同期設定ファイルのパス                                                     |
+| `upstream-manifest` |    no    | —                             | upstream マニフェスト参照 (`owner/repo@ref:path` 形式)。詳細は第 12 章参照 |
+
+### 11.3 gh-sync init --with-workflow
+
+`gh-sync init` に `--with-workflow` フラグを追加。config.yaml・schema.json の生成に加えて
+`.github/workflows/gh-sync.yaml` を生成する。
+
+- 非インタラクティブ (`stdin` が TTY でない) 時は `--with-workflow` を明示した場合のみ生成。
+- TTY 時はモード選択後にインタラクティブな確認プロンプトを表示する。
+- 既存ファイルがある場合は `--force` がなければ上書き確認を行う (非 TTY では bail)。
+- 埋め込まれるバージョンは `gh-sync` 実行時の `CARGO_PKG_VERSION` (例: `v0.1.3`)。
+
+```bash
+# 非インタラクティブ例
+gh-sync init --repo naa0yama/boilerplate-rust --from-upstream --with-workflow --force
+```
+
+生成される `.github/workflows/gh-sync.yaml` の内容 (`--repo owner/repo` 指定時):
+
+```yaml
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: gh-sync check
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+  schedule:
+    - cron: "0 18 * * *" # daily at 03:00 JST
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  gh-sync-check:
+    name: gh-sync-check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@<sha> # vX.Y.Z
+        with:
+          persist-credentials: false
+      - uses: naa0yama/gh-sync@<version>
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          upstream-manifest: owner/repo@main:.github/gh-sync/config.yaml
+```
+
+## 12. upstream manifest と local overlay
+
+### 12.1 概要
+
+マニフェストを各 downstream リポジトリに個別に配置するのではなく、
+upstream テンプレートリポジトリ (例: `naa0yama/boilerplate-rust`) で一元管理し、
+downstream は `--upstream-manifest` でそれを参照する構成を取れる。
+
+downstream が特殊なカスタマイズを必要とする場合は、ローカルに overlay マニフェストを
+置くことで upstream の定義を選択的に上書き・除外できる。
+
+### 12.2 upstream manifest 参照形式
+
+```
+owner/repo@ref:path
+```
+
+| 要素         | 説明                                        | 省略時のデフォルト |
+| ------------ | ------------------------------------------- | ------------------ |
+| `owner/repo` | upstream リポジトリ (`owner/name` 形式必須) | —                  |
+| `@ref`       | ブランチ、タグ、またはコミット SHA          | `HEAD`             |
+| `:path`      | リポジトリ内のマニフェストファイルパス      | (省略不可)         |
+
+**例:**
+
+```
+naa0yama/boilerplate-rust@main:.github/gh-sync/config.yaml
+naa0yama/boilerplate-rust@v1.0.0:.github/gh-sync/config.yaml
+naa0yama/boilerplate-rust:.github/gh-sync/config.yaml  # ref 省略 → HEAD
+```
+
+### 12.3 マニフェスト解決ロジック
+
+1. `--upstream-manifest` が指定された場合:
+   - 指定された参照を `gh api` で取得し、YAML をパースする
+   - `--manifest` に指定されたローカルファイルが存在すれば、`merge_overlay` を適用する
+   - ローカルファイルが存在しない場合は upstream マニフェストをそのまま使用する
+2. `--upstream-manifest` が指定されない場合:
+   - 従来どおり `--manifest` のローカルファイルのみを使用する
+
+### 12.4 マージ規則
+
+`merge_overlay(upstream, local)` の適用規則:
+
+#### `upstream:` ノード
+
+local マニフェストが存在する場合、local の `upstream:` ノードが upstream のものを
+**完全に置換**する。部分マージは行わない。
+
+#### `spec:` ノード
+
+フィールド単位で **local 優先**マージを行う。`Option<T>` フィールドは
+local が `Some` のときのみ上書きし、`None` のときは upstream の値を継承する。
+
+#### `files:` リスト
+
+`path` を key にマージする:
+
+| 状態                              | 結果                                |
+| --------------------------------- | ----------------------------------- |
+| upstream のみに存在               | upstream ルールをそのまま採用       |
+| local のみに存在                  | local ルールを末尾に追加            |
+| 両方に存在                        | local ルールで **完全置換**         |
+| 両方に存在 かつ local が `ignore` | 当該 path をマージ結果から **削除** |
+| local のみに存在 かつ `ignore`    | マージ結果に追加しない (無視)       |
+
+### 12.5 strategy: ignore
+
+`strategy: ignore` は **local overlay 専用**の戦略で、upstream で定義されたルールを
+downstream が明示的に除外するために使う。
+
+```yaml
+# local overlay (.github/gh-sync/config.yaml)
+upstream:
+  repo: naa0yama/boilerplate-rust
+  ref: main
+files:
+  # upstream で定義された Cargo.toml の patch ルールを除外する
+  - path: Cargo.toml
+    strategy: ignore
+  # upstream にないローカル固有のルールを追加
+  - path: .project-config.json
+    strategy: create_only
+```
+
+**制約:**
+
+- `source` フィールドは指定できない (`delete` と同じ制約)
+- `patch` フィールドは指定できない
+- ドリフト検知・sync の両対象から除外される (patch ファイルの存在チェックも対象外)
+
+### 12.6 GitHub Actions での使用例
+
+**純 upstream 動作** (downstream に local manifest なし):
+
+```yaml
+- uses: naa0yama/gh-sync@v0.1.3
+  with:
+    token: ${{ secrets.GITHUB_TOKEN }}
+    upstream-manifest: naa0yama/boilerplate-rust@main:.github/gh-sync/config.yaml
+```
+
+**local overlay あり** (downstream に上書きルールを定義):
+
+```yaml
+- uses: naa0yama/gh-sync@v0.1.3
+  with:
+    token: ${{ secrets.GITHUB_TOKEN }}
+    upstream-manifest: naa0yama/boilerplate-rust@main:.github/gh-sync/config.yaml
+    manifest: .github/gh-sync/config.yaml
+```


### PR DESCRIPTION
## Summary

- **`strategy: ignore`** を `gh-sync-manifest` に追加し、local overlay で upstream のエントリを打ち消せるようにした
- **`merge_overlay(upstream, local)`** を実装し、`upstream:` ノード・`spec:` フィールド・`files:` エントリを local-wins でマージする
- **`--upstream-manifest owner/repo@ref:path`** CLI フラグを追加し、upstream からマニフェストを取得して local と自動マージする
- **`action.yml`** を追加し、downstream リポジトリが `uses: naa0yama/gh-sync@<tag>` で組み込めるようにした
- **`gh-sync init --with-workflow`** フラグを追加し、GitHub Actions ワークフロー雛形を自動生成できるようにした
- **`.github/workflows/gh-sync.yaml`** を追加し、このリポジトリ自体が gh-sync で自己チェックするようにした
- README と仕様書 (`docs/specs/template-sync.ja.md`) にドキュメントを追加した

## Commits

| # | commit | 内容 |
|---|--------|------|
| 1 | `a3951b8` | `feat(manifest)`: Strategy::Ignore + merge_overlay |
| 2 | `7351433` | `feat(engine)`: Ignore strategy を sync モードで skip |
| 3 | `4f24480` | `feat(cli)`: --upstream-manifest フラグ + manifest resolver |
| 4 | `fa89ad0` | `feat(action)`: GitHub Actions composite action 定義 |
| 5 | `a55903c` | `feat(init)`: --with-workflow フラグ追加 |
| 6 | `6f52136` | `ci`: 自己チェックワークフロー + .ghalint.yaml |
| 7 | `0d97f16` | `docs`: README + 仕様書更新 |

## Test plan

- [ ] `mise run test` — 全テスト green (unit + integration)
- [ ] `mise run pre-commit` — clippy:strict / ast-grep / lint:gh green
- [ ] `--upstream-manifest` のみ指定 (local manifest なし) で `--ci-check` が動作する
- [ ] local manifest の `strategy: ignore` が upstream エントリを除外する
- [ ] `gh-sync init --with-workflow` が `.github/workflows/gh-sync.yaml` を生成し actionlint を通る