### PR TITLE
fix(release): use draft release to allow asset upload before publishing

### DIFF
--- a/.github/actions/upload-release-assets/action.yaml
+++ b/.github/actions/upload-release-assets/action.yaml
@@ -131,12 +131,22 @@ runs:
         set -euo pipefail
         shopt -s failglob
 
-        # Verify the release exists (tagpr creates it synchronously before this workflow runs)
+        # Verify the release exists (tagpr creates it as draft before this workflow runs)
         release_url="$(gh release view "${TAG}" --json url --jq '.url')"
         echo "Release found: ${release_url}"
 
         gh release upload "${TAG}" release-assets/* --clobber
         echo "url=${release_url}" >> "$GITHUB_OUTPUT"
+
+    - name: Publish release
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        TAG: ${{ inputs.tag }}
+      run: |
+        set -euo pipefail
+        gh release edit "${TAG}" --draft=false --latest
+        echo "Release ${TAG} published successfully"
 
     - name: Release summary
       shell: bash

--- a/.github/gh-sync/config.yaml
+++ b/.github/gh-sync/config.yaml
@@ -224,6 +224,7 @@ spec:
         - "k1low/gh-setup@*"
         - "k1low/octocov-action@*"
         - "mozilla-actions/sccache-action@*"
+        - "naa0yama/gh-sync@*"
         - "songmu/tagpr@*"
         - "swatinem/rust-cache@*"
         - "taiki-e/install-action@*"

--- a/.tagpr
+++ b/.tagpr
@@ -53,3 +53,4 @@
 	changelog = true
 	template = ".github/tagpr-template.md"
 	postVersionCommand = "cargo generate-lockfile && git add Cargo.lock"
+	release = draft

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
   token:
     description: >
       GitHub token for gh release download and for the gh CLI inside gh-sync.
-      Pass ${{ secrets.GITHUB_TOKEN }} or a PAT with repo read scope.
+      Pass secrets.GITHUB_TOKEN or a PAT with repo read scope.
     required: true
 
 runs:


### PR DESCRIPTION
## 概要

- `tagpr` がデフォルトで `immutable: true` のリリースを作成するため、`gh release upload` が `HTTP 422` で失敗していた問題を修正
- `.tagpr` に `release = draft` を追加し、`tagpr` が draft リリースを作成するよう変更
- `upload-release-assets` action に `Publish release` ステップを追加し、アセットアップロード後に `gh release edit --draft=false --latest` でリリースを公開する
- `action.yml` の `token` input description 内の `${{ secrets.GITHUB_TOKEN }}` を plain text に変更
  (composite action では description も expression として評価され `Unrecognized named-value: secrets` が出て startup 失敗していた)
- `.github/gh-sync/config.yaml` の `patterns_allowed` に `naa0yama/gh-sync@*` を追加

> [!NOTE]
> `gh-sync-check` は `action.yml` の修正を含む v0.1.4 のリリース後に `gh-sync.yaml` の固定 SHA を更新することで完全に解消する予定。

## テスト計画

- [x] `mise run pre-commit` パス (clippy, fmt, actionlint, ast-grep)
- [x] ログ解析により根本原因を特定 (`immutable: true` フィールドを API で確認)
- [x] `action.yml` の expression syntax 修正
- [ ] 次回リリース (v0.1.4) 時に `Upload Release Assets` ジョブが成功することを確認
- [ ] リリースが draft 状態で作成され、アセットアップロード後に公開されることを確認
- [ ] v0.1.4 リリース後に `gh-sync.yaml` の固定 SHA を更新し `gh-sync-check` が通ることを確認