### PR TITLE
fix: prevent GitHub API 422 for merge-method and allowed_actions constraints

### DIFF
--- a/.claude/artifacts/api-422-guards/PLAN.md
+++ b/.claude/artifacts/api-422-guards/PLAN.md
@@ -1,0 +1,29 @@
+# Plan: GitHub API 422 Guard Improvements
+
+Spec: docs/specs/2026-04-16-api-422-guards-design.md
+
+## Tasks
+
+### Task 1: All-merge-methods-false guard
+
+File: crates/gh-sync-manifest/src/manifest.rs
+
+- Added validation rule in validate_schema() rejecting specs where all three
+  merge methods are explicitly false.
+- Added 2 tests: all-disabled triggers error, one-enabled passes.
+
+### Task 2: allowed_actions constraints
+
+File: crates/gh-sync-manifest/src/manifest.rs
+
+- Added Rule A: invalid allowed_actions value (not all/local_only/selected)
+- Added Rule B: allowed_actions "selected" without populated selected_actions
+- Added 4 tests covering both error and valid-pass cases.
+
+### Prior fix (separate commit): apply.rs title/message stripping
+
+File: crates/gh-sync-engine/src/repo/apply.rs
+
+- Strip merge_commit_title/message when allow_merge_commit: false
+- Strip squash_commit_title/message when allow_squash_merge: false
+- Added 3 tests; test assertions updated to use .get().is_none() pattern.

--- a/.claude/artifacts/api-422-guards/REVIEW.md
+++ b/.claude/artifacts/api-422-guards/REVIEW.md
@@ -1,0 +1,30 @@
+# Review: GitHub API 422 Guards
+
+## Stage A (Spec Compliance)
+
+### Task 1
+
+- Plan alignment: PASS
+- Scope: manifest.rs only: PASS
+- Completeness: no TODOs: PASS
+- Naming: ValidationError::top_level pattern: PASS
+- Tests: 2 added: PASS
+
+### Task 2
+
+- Plan alignment: PASS
+- Scope: manifest.rs only: PASS
+- Completeness: no TODOs: PASS
+- Naming: let-chain style: PASS
+- Tests: 4 added: PASS
+
+## Stage B (Code Quality Review)
+
+Reviewer verdict: NEEDS WORK → fixed
+
+Issues found and resolved:
+
+1. cargo fmt failure in manifest.rs lines 621-625 → fixed via cargo fmt
+2. as_object().unwrap() in engine tests → replaced with .get().is_none()
+
+Final state: all 477 tests pass, pre-commit clean.

--- a/crates/gh-sync-engine/src/repo/apply.rs
+++ b/crates/gh-sync-engine/src/repo/apply.rs
@@ -95,6 +95,17 @@ fn apply_core_fields(
         }
     }
 
+    // GitHub API rejects merge-method title/message fields when the method is
+    // disabled. Strip them when the same PATCH disables the method.
+    if patch.get("allow_merge_commit") == Some(&serde_json::json!(false)) {
+        patch.remove("merge_commit_title");
+        patch.remove("merge_commit_message");
+    }
+    if patch.get("allow_squash_merge") == Some(&serde_json::json!(false)) {
+        patch.remove("squash_merge_commit_title");
+        patch.remove("squash_merge_commit_message");
+    }
+
     if !patch.is_empty() {
         tracing::info!("applying repository settings");
         client.patch_repo(repo, &serde_json::Value::Object(patch))?;

--- a/crates/gh-sync-engine/src/repo/tests.rs
+++ b/crates/gh-sync-engine/src/repo/tests.rs
@@ -3498,3 +3498,94 @@ fn print_preview_ruleset_update_no_live_data() {
     assert!(output.contains("rules.deletion"));
     assert!(output.contains("rules.required_signatures"));
 }
+
+// ------------------------------------------------------------------
+// apply: merge-method/title stripping (GitHub API 422 guard)
+// ------------------------------------------------------------------
+
+#[test]
+fn apply_core_fields_strips_merge_commit_fields_when_disabled() {
+    let spec = make_spec();
+    let client = MockRepoClient::new("owner/repo");
+    let changes = vec![
+        SpecChange::FieldChanged {
+            field: String::from("merge_strategy.allow_merge_commit"),
+            old: String::from("true"),
+            new: String::from("false"),
+        },
+        SpecChange::FieldChanged {
+            field: String::from("merge_strategy.merge_commit_title"),
+            old: String::from("MERGE_MESSAGE"),
+            new: String::from("PR_TITLE"),
+        },
+        SpecChange::FieldChanged {
+            field: String::from("merge_strategy.merge_commit_message"),
+            old: String::from("BLANK"),
+            new: String::from("PR_TITLE"),
+        },
+    ];
+    apply_changes(&changes, &spec, "owner/repo", &client).unwrap();
+    let patches = client.applied_patches.borrow();
+    assert_eq!(patches.len(), 1);
+    assert_eq!(patches[0]["allow_merge_commit"], false);
+    assert!(patches[0].get("merge_commit_title").is_none());
+    assert!(patches[0].get("merge_commit_message").is_none());
+}
+
+#[test]
+fn apply_core_fields_strips_squash_fields_when_disabled() {
+    let spec = make_spec();
+    let client = MockRepoClient::new("owner/repo");
+    let changes = vec![
+        SpecChange::FieldChanged {
+            field: String::from("merge_strategy.allow_squash_merge"),
+            old: String::from("true"),
+            new: String::from("false"),
+        },
+        SpecChange::FieldChanged {
+            field: String::from("merge_strategy.squash_merge_commit_title"),
+            old: String::from("COMMIT_OR_PR_TITLE"),
+            new: String::from("PR_TITLE"),
+        },
+        SpecChange::FieldChanged {
+            field: String::from("merge_strategy.squash_merge_commit_message"),
+            old: String::from("BLANK"),
+            new: String::from("PR_BODY"),
+        },
+    ];
+    apply_changes(&changes, &spec, "owner/repo", &client).unwrap();
+    let patches = client.applied_patches.borrow();
+    assert_eq!(patches.len(), 1);
+    assert_eq!(patches[0]["allow_squash_merge"], false);
+    assert!(patches[0].get("squash_merge_commit_title").is_none());
+    assert!(patches[0].get("squash_merge_commit_message").is_none());
+}
+
+#[test]
+fn apply_core_fields_keeps_merge_commit_fields_when_enabled() {
+    let spec = make_spec();
+    let client = MockRepoClient::new("owner/repo");
+    let changes = vec![
+        SpecChange::FieldChanged {
+            field: String::from("merge_strategy.allow_merge_commit"),
+            old: String::from("false"),
+            new: String::from("true"),
+        },
+        SpecChange::FieldChanged {
+            field: String::from("merge_strategy.merge_commit_title"),
+            old: String::from("MERGE_MESSAGE"),
+            new: String::from("PR_TITLE"),
+        },
+        SpecChange::FieldChanged {
+            field: String::from("merge_strategy.merge_commit_message"),
+            old: String::from("BLANK"),
+            new: String::from("PR_TITLE"),
+        },
+    ];
+    apply_changes(&changes, &spec, "owner/repo", &client).unwrap();
+    let patches = client.applied_patches.borrow();
+    assert_eq!(patches.len(), 1);
+    assert_eq!(patches[0]["allow_merge_commit"], true);
+    assert_eq!(patches[0]["merge_commit_title"], "PR_TITLE");
+    assert_eq!(patches[0]["merge_commit_message"], "PR_TITLE");
+}

--- a/crates/gh-sync-manifest/src/manifest.rs
+++ b/crates/gh-sync-manifest/src/manifest.rs
@@ -589,6 +589,45 @@ pub fn validate_schema(manifest: &Manifest) -> Result<(), SyncError> {
         validate_action_patterns(patterns, &mut errors);
     }
 
+    // spec.merge_strategy: at least one merge method must be enabled
+    if let Some(spec) = &manifest.spec
+        && let Some(ms) = &spec.merge_strategy
+        && ms.allow_merge_commit == Some(false)
+        && ms.allow_squash_merge == Some(false)
+        && ms.allow_rebase_merge == Some(false)
+    {
+        errors.push(ValidationError::top_level(
+            "spec.merge_strategy",
+            "at least one merge method must be enabled (allow_merge_commit, allow_squash_merge, or allow_rebase_merge)",
+        ));
+    }
+
+    if let Some(spec) = &manifest.spec
+        && let Some(actions) = &spec.actions
+        && let Some(value) = &actions.allowed_actions
+        && !matches!(value.as_str(), "all" | "local_only" | "selected")
+    {
+        errors.push(ValidationError::top_level(
+            "spec.actions.allowed_actions",
+            format!("must be one of 'all', 'local_only', 'selected'; got '{value}'"),
+        ));
+    }
+
+    // spec.actions.selected_actions: required when allowed_actions is "selected"
+    if let Some(spec) = &manifest.spec
+        && let Some(actions) = &spec.actions
+        && actions.allowed_actions.as_deref() == Some("selected")
+        && (actions.selected_actions.is_none()
+            || actions.selected_actions.as_ref().is_some_and(|sa| {
+                sa.github_owned_allowed.is_none() && sa.patterns_allowed.is_none()
+            }))
+    {
+        errors.push(ValidationError::top_level(
+            "spec.actions.selected_actions",
+            "required when allowed_actions is 'selected': set github_owned_allowed or patterns_allowed",
+        ));
+    }
+
     if errors.is_empty() {
         Ok(())
     } else {
@@ -1457,6 +1496,121 @@ files:
         assert_eq!(Strategy::Delete.to_string(), "delete");
         assert_eq!(Strategy::Patch.to_string(), "patch");
         assert_eq!(Strategy::Ignore.to_string(), "ignore");
+    }
+
+    // --- validate_schema: merge_strategy all-disabled guard ---
+
+    #[cfg_attr(miri, ignore = "libyml ptr_offset_from UB under Miri")]
+    #[test]
+    fn validate_schema_merge_strategy_all_disabled_is_error() {
+        expect_schema_error(
+            r"
+upstream:
+  repo: owner/repo
+files:
+  - path: foo.txt
+    strategy: replace
+spec:
+  merge_strategy:
+    allow_merge_commit: false
+    allow_squash_merge: false
+    allow_rebase_merge: false
+",
+            "spec.merge_strategy",
+        );
+    }
+
+    #[cfg_attr(miri, ignore = "libyml ptr_offset_from UB under Miri")]
+    #[test]
+    fn validate_schema_merge_strategy_one_enabled_is_ok() {
+        expect_schema_ok(
+            r"
+upstream:
+  repo: owner/repo
+files:
+  - path: foo.txt
+    strategy: replace
+spec:
+  merge_strategy:
+    allow_merge_commit: false
+    allow_squash_merge: false
+    allow_rebase_merge: true
+",
+        );
+    }
+
+    // --- validate_schema: allowed_actions ---
+
+    #[cfg_attr(miri, ignore = "libyml ptr_offset_from UB under Miri")]
+    #[test]
+    fn validate_schema_allowed_actions_invalid_value_is_error() {
+        expect_schema_error(
+            r"
+upstream:
+  repo: owner/repo
+files:
+  - path: foo.txt
+    strategy: replace
+spec:
+  actions:
+    allowed_actions: bad_value
+",
+            "spec.actions.allowed_actions",
+        );
+    }
+
+    #[cfg_attr(miri, ignore = "libyml ptr_offset_from UB under Miri")]
+    #[test]
+    fn validate_schema_allowed_actions_valid_value_is_ok() {
+        expect_schema_ok(
+            r"
+upstream:
+  repo: owner/repo
+files:
+  - path: foo.txt
+    strategy: replace
+spec:
+  actions:
+    allowed_actions: all
+",
+        );
+    }
+
+    #[cfg_attr(miri, ignore = "libyml ptr_offset_from UB under Miri")]
+    #[test]
+    fn validate_schema_allowed_actions_selected_without_patterns_is_error() {
+        expect_schema_error(
+            r"
+upstream:
+  repo: owner/repo
+files:
+  - path: foo.txt
+    strategy: replace
+spec:
+  actions:
+    allowed_actions: selected
+",
+            "spec.actions.selected_actions",
+        );
+    }
+
+    #[cfg_attr(miri, ignore = "libyml ptr_offset_from UB under Miri")]
+    #[test]
+    fn validate_schema_allowed_actions_selected_with_patterns_is_ok() {
+        expect_schema_ok(
+            r"
+upstream:
+  repo: owner/repo
+files:
+  - path: foo.txt
+    strategy: replace
+spec:
+  actions:
+    allowed_actions: selected
+    selected_actions:
+      github_owned_allowed: true
+",
+        );
     }
 
     #[cfg_attr(miri, ignore = "tempfile I/O not supported under Miri")]

--- a/crates/gh-sync/src/sync/repo.rs
+++ b/crates/gh-sync/src/sync/repo.rs
@@ -600,14 +600,6 @@ fn execute_inner(
     client: &dyn GhRepoClient,
     w: &mut dyn Write,
 ) -> ExitCode {
-    // Resolve the directory containing the manifest as the repo root.
-    let repo_root = args
-        .manifest
-        .parent()
-        .and_then(|p| p.parent())
-        .and_then(|p| p.parent())
-        .unwrap_or_else(|| std::path::Path::new("."));
-
     // Resolve the effective manifest (upstream fetch + optional local overlay,
     // or just local file when --upstream-manifest is not given).
     let fetcher = GhFetcher;
@@ -623,13 +615,11 @@ fn execute_inner(
         }
     };
 
-    // Validate schema and local references before making any API calls.
+    // Validate schema before making any API calls.
     // A misconfigured manifest must be caught early to prevent partial apply.
+    // validate_references() (patch file existence) is intentionally skipped:
+    // sync repo only uses spec: settings and never reads patch files.
     if let Err(e) = manifest::validate_schema(&manifest) {
-        tracing::error!("manifest validation failed: {e}");
-        return ExitCode::FAILURE;
-    }
-    if let Err(e) = manifest::validate_references(&manifest, repo_root) {
         tracing::error!("manifest validation failed: {e}");
         return ExitCode::FAILURE;
     }

--- a/docs/specs/2026-04-16-api-422-guards-design.md
+++ b/docs/specs/2026-04-16-api-422-guards-design.md
@@ -1,0 +1,75 @@
+# Design: GitHub API 422 Guard Improvements
+
+## Problem
+
+`gh-sync sync repo` can produce HTTP 422 (Validation Failed) errors from the
+GitHub API when the PATCH payload contains field combinations that GitHub
+rejects. One case (disabling a merge method while changing its title/message
+fields in the same request) was fixed in a prior commit. This spec covers the
+remaining high-priority cases.
+
+## Goals
+
+- Prevent HTTP 422 when the spec disables all three merge methods at once.
+- Prevent HTTP 422 when `allowed_actions: selected` is set without any
+  `selected_actions` defined.
+- Prevent silent typos in `allowed_actions` from reaching the GitHub API.
+- Detect all three conditions at manifest-validation time, before any API call.
+
+## Non-Goals
+
+- `archived: true` combined with other fields: no confirmed GitHub API
+  constraint found; deferred pending evidence.
+- `required_status_checks` with empty contexts: GitHub acceptance unclear;
+  deferred pending evidence.
+- Runtime checks against live repository state (edge cases where two methods
+  are already false in the live repo are not addressed).
+
+## Approach
+
+All three fixes are added to `validate_schema()` in
+`crates/gh-sync-manifest/src/manifest.rs`. This function already runs before
+any API call, returns structured `ValidationError` items, and is covered by
+existing tests — making it the lowest-risk insertion point.
+
+No changes to `apply_core_fields()` are needed for these cases (the merge
+method guard fits naturally as a spec-level constraint).
+
+## Implementation Notes
+
+### Task 1 — All merge methods disabled (Issue #1)
+
+File: `crates/gh-sync-manifest/src/manifest.rs` — `validate_schema()`
+
+If `merge_strategy` has all three of `allow_merge_commit`,
+`allow_squash_merge`, and `allow_rebase_merge` explicitly set to `false`,
+push a `ValidationError::top_level` on field
+`"spec.merge_strategy"` with message
+`"at least one merge method must be enabled"`.
+
+### Task 2 — `allowed_actions` constraints (Issues #3 and #4)
+
+File: `crates/gh-sync-manifest/src/manifest.rs` — `validate_schema()`
+
+**Issue #4 (invalid value):** If `actions.allowed_actions` is present but
+not one of `"all"`, `"local_only"`, `"selected"`, push a
+`ValidationError::top_level` on field `"spec.actions.allowed_actions"`.
+
+**Issue #3 (selected without patterns):** If `actions.allowed_actions` is
+`"selected"` and `actions.selected_actions` is `None` (or both
+`github_owned_allowed` and `patterns_allowed` are `None`), push a
+`ValidationError::top_level` on field `"spec.actions.selected_actions"`.
+
+## Testing Strategy
+
+Each new validation path gets at least two unit tests in
+`crates/gh-sync-manifest/src/manifest.rs` (inline `#[cfg(test)]` block):
+
+- One test that triggers the new error.
+- One test that confirms a valid spec passes.
+
+Run `mise run test` and `mise run pre-commit` to verify.
+
+## Open Questions
+
+None.


### PR DESCRIPTION
## Summary

- `apply_core_fields()` が `allow_merge_commit: false` や `allow_squash_merge: false` と同時にタイトル/メッセージフィールドを送信して GitHub API 422 が返る問題を修正
- `validate_schema()` に 3 つのガードを追加: 全マージ方式同時無効化・`allowed_actions` 無効値・`allowed_actions: selected` の `selected_actions` 未設定
- `sync repo` が `validate_references()` (patch ファイル存在チェック) を呼ぶため、`sync file` より先に実行できない問題を修正

## 変更内容

### `fix(engine)`: strip merge-method fields when method is disabled

GitHub API は `allow_merge_commit: false` と同時に `merge_commit_title`/`merge_commit_message` が含まれる PATCH を 422 で拒否する。`allow_squash_merge: false` と squash 系フィールドも同様。

送信前にパッチマップから依存フィールドを除去するよう修正。

### `fix(manifest)`: add schema validation guards for 422 prevention

`validate_schema()` に以下を追加:

- `allow_merge_commit`/`allow_squash_merge`/`allow_rebase_merge` が 3 つとも `false` のとき拒否 (GitHub は最低 1 つ有効化を必要とする)
- `allowed_actions` が `all`/`local_only`/`selected` 以外のとき拒否
- `allowed_actions: selected` かつ `selected_actions` が未設定または空のとき拒否

### `fix(sync)`: skip validate_references() in sync repo

`sync repo` は `spec:` セクションのみを扱い、patch ファイルを一切参照しない。
`validate_references()` を呼ぶことで `sync file --patch-refresh` より先に `sync repo` を実行できなかった。

`sync file` の通常モードと同様に `validate_schema()` のみに統一。

## テスト計画

- [ ] `mise run test` — 全テスト通過 (477 テスト)
- [ ] `mise run pre-commit` — format/clippy/lint 通過