### PR TITLE
ci: restructure PR label pipeline and release categories

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -35,7 +35,6 @@ documentation:
       - any-glob-to-any-file:
           - "docs/**"
           - "README.md"
-          - "**/*.md"
 
 # Dependency management
 renovate-config:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -7,34 +7,27 @@ changelog:
 
   categories:
     - title: Features 🎉
-      labels: ["enhancement"]
+      labels:
+        - enhancement
+        - feature
     - title: Bug Fixes 🐌
-      labels: ["bug"]
+      labels:
+        - bug
+        - fix
     - title: Documentation 🗒️
-      labels: ["documentation"]
+      labels:
+        - documentation
     - title: "Dependency Updates 📦"
-      labels: ["renovate"]
-      exclude:
-        labels:
-          [
-            "manager:mise",
-            "manager:github-actions",
-            "manager:dockerfile",
-            "manager:regex",
-            "github-actions",
-            "core",
-            "renovate-config",
-          ]
+      labels:
+        - manager:cargo
     - title: "Development Environment 🔧"
       labels:
-        [
-          "manager:mise",
-          "manager:github-actions",
-          "manager:dockerfile",
-          "manager:regex",
-          "github-actions",
-          "core",
-          "renovate-config",
-        ]
+        - manager:mise
+        - manager:github-actions
+        - managers:dockerfile
+        - managers:docker-compose
+        - manager:regex
+        - github-actions
+        - renovate-config
     - title: Other Changes
       labels: ["*"]

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -21,3 +21,18 @@ jobs:
 
     steps:
       - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
+
+      - name: Auto-label by Conventional Commit prefix
+        if: github.event.pull_request.user.type != 'Bot'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          if   [[ "$PR_TITLE" =~ ^(feat|perf|refactor|remove|update)(\(|:) ]]; then label=enhancement
+          elif [[ "$PR_TITLE" =~ ^(fix|revert)(\(|:)                       ]]; then label=bug
+          elif [[ "$PR_TITLE" =~ ^docs(\(|:)                               ]]; then label=documentation
+          else echo "No matching prefix in: $PR_TITLE"; exit 0
+          fi
+          gh pr edit "$PR_NUMBER" --add-label "$label"


### PR DESCRIPTION
## 概要

- `release.yml` のカテゴリを実態のラベルに合わせて再構築した
  - **Dependency Updates 📦** を `manager:cargo` のみに限定 (whitelist 方式)
  - **Development Environment 🔧** から `core` / `tests` を削除し、開発インフララベルのみで構成
  - `managers:dockerfile` / `managers:docker-compose` を追加 (renovate-config の `extends/docker.json` が付与する複数形に対応)
- `labeler.yml` の `documentation` glob から `**/*.md` を削除し、`docs/**` と `README.md` のみに限定
  - これにより `feat:` / `fix:` PR が Markdown ファイルに触れるだけで Documentation に誤分類される問題を解消
- `pr-labeler.yaml` に Conventional Commit prefix → ラベル自動付与 step を追加
  - `feat/perf/refactor/remove/update` → `enhancement`
  - `fix/revert` → `bug`
  - `docs` → `documentation`
  - Bot 作成 PR (Renovate / tagpr) はスキップ

## 背景 (過去リリースでの誤分類)

| リリース | PR | タイトル | 旧分類 | 期待 |
|---|---|---|---|---|
| v0.1.3 | #5 / #11 | `feat:` | Documentation | Features |
| v0.1.3 | #7 | `fix(config):` | Other Changes | Bug Fixes |
| v0.1.4 | #14 | `fix(release):` | Dev Environment | Bug Fixes |
| v0.1.5 | #16 | `feat: add gh-sync pr subcommand` | Dev Environment | Features |
| v0.2.0 | #19 / #21 | `remove:` / `fix:` | Documentation | Features / Bug Fixes |