### PR TITLE
feat(engine): add diff context header annotation to sync/ci-check diff output

### DIFF
--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -35,4 +35,4 @@ jobs:
           elif [[ "$PR_TITLE" =~ ^docs(\(|:)                               ]]; then label=documentation
           else echo "No matching prefix in: $PR_TITLE"; exit 0
           fi
-          gh pr edit "$PR_NUMBER" --add-label "$label"
+          gh pr edit "$PR_NUMBER" --add-label "$label" --repo "$GITHUB_REPOSITORY"

--- a/crates/gh-sync-engine/src/mode/ci_check.rs
+++ b/crates/gh-sync-engine/src/mode/ci_check.rs
@@ -8,8 +8,8 @@ use gh_sync_manifest::{self as manifest, Manifest, Rule, Strategy};
 
 use crate::diff::unified_diff;
 use crate::output::{
-    DriftOutcome, StatusTag, Summary, build_pr_comment, emit_diff, emit_drift_summary,
-    emit_gha_annotations, emit_status,
+    DriftOutcome, StatusTag, Summary, build_diff_context_header, build_pr_comment, emit_diff,
+    emit_drift_summary, emit_gha_annotations, emit_status,
 };
 use crate::strategy::patch::PatchRunner;
 use crate::strategy::{self, StrategyResult};
@@ -178,7 +178,14 @@ fn evaluate_drift(
             if local_content == expected.as_slice() {
                 (false, String::from("up to date"), String::new(), false)
             } else {
-                let diff = unified_diff(&rule.path, local_content, &expected).unwrap_or_default();
+                let body = unified_diff(&rule.path, local_content, &expected).unwrap_or_default();
+                let diff = if body.is_empty() {
+                    String::new()
+                } else {
+                    let header =
+                        build_diff_context_header(&manifest.upstream.repo, &manifest.upstream.ref_);
+                    format!("{header}\n{body}")
+                };
                 (true, String::from("upstream has changes"), diff, false)
             }
         }
@@ -315,6 +322,10 @@ mod tests {
         let out = String::from_utf8(buf).unwrap();
         assert!(matches!(code, ExitCode::FAILURE), "expected FAILURE: {out}");
         assert!(out.contains("[DRIFT"), "expected DRIFT: {out}");
+        assert!(
+            out.contains("# a/ = local, b/ = upstream (owner/repo@main)"),
+            "missing diff context header: {out}"
+        );
     }
 
     #[test]

--- a/crates/gh-sync-engine/src/mode/patch_refresh.rs
+++ b/crates/gh-sync-engine/src/mode/patch_refresh.rs
@@ -109,6 +109,7 @@ pub fn run(
                 Ok(FetchResult::Content(bytes)) => bytes,
             };
 
+        // old=upstream, new=local: output is a patch to apply to upstream to reproduce local state
         let diff = match unified_diff(&rule.path, &upstream, &local_bytes) {
             Ok(d) => d,
             Err(e) => {

--- a/crates/gh-sync-engine/src/mode/sync.rs
+++ b/crates/gh-sync-engine/src/mode/sync.rs
@@ -8,7 +8,10 @@ use anyhow::Context as _;
 use gh_sync_manifest::{self as manifest, Manifest, Strategy};
 
 use crate::diff::unified_diff;
-use crate::output::{RuleOutcome, StatusTag, Summary, emit_diff, emit_status, emit_summary};
+use crate::output::{
+    RuleOutcome, StatusTag, Summary, build_diff_context_header, emit_diff, emit_status,
+    emit_summary,
+};
 use crate::strategy::patch::PatchRunner;
 use crate::strategy::{self, StrategyResult};
 use crate::upstream::{FetchResult, UpstreamFetcher};
@@ -109,7 +112,14 @@ pub fn run(
         let diff = match &result {
             StrategyResult::Changed { content } => {
                 let old = local_bytes.as_deref().unwrap_or(b"");
-                unified_diff(&rule.path, old, content).unwrap_or_default()
+                let body = unified_diff(&rule.path, old, content).unwrap_or_default();
+                if body.is_empty() {
+                    String::new()
+                } else {
+                    let header =
+                        build_diff_context_header(&manifest.upstream.repo, &manifest.upstream.ref_);
+                    format!("{header}\n{body}")
+                }
             }
             _ => String::new(),
         };
@@ -284,6 +294,10 @@ mod tests {
         let out = String::from_utf8(buf).unwrap();
         assert!(matches!(code, ExitCode::SUCCESS), "expected SUCCESS: {out}");
         assert!(out.contains("[CHANGED]"), "missing CHANGED tag: {out}");
+        assert!(
+            out.contains("# a/ = local, b/ = upstream (owner/repo@main)"),
+            "missing diff context header: {out}"
+        );
         let written = std::fs::read(dir.path().join("ci.yml")).unwrap();
         assert_eq!(written, b"upstream content\n");
     }

--- a/crates/gh-sync-engine/src/output.rs
+++ b/crates/gh-sync-engine/src/output.rs
@@ -132,7 +132,10 @@ pub fn colorize_diff(diff: &str) -> String {
 
     diff.lines()
         .map(|line| {
-            if line.starts_with("---") || line.starts_with("+++") {
+            if line.starts_with('#') {
+                // Annotation comment (e.g. "# a/ = local, b/ = upstream ..."): dim
+                format!("{}\n", style(line).dim())
+            } else if line.starts_with("---") || line.starts_with("+++") {
                 // File header lines: bold
                 format!("{}\n", style(line).bold())
             } else if line.starts_with("@@") {
@@ -149,6 +152,15 @@ pub fn colorize_diff(diff: &str) -> String {
             }
         })
         .collect()
+}
+
+/// Build the one-line annotation prepended to diff output to identify each side.
+///
+/// Returns `# a/ = local, b/ = upstream ({repo}@{ref})` without a trailing
+/// newline.  Callers are responsible for appending `\n` when concatenating.
+#[must_use]
+pub fn build_diff_context_header(upstream_repo: &str, upstream_ref: &str) -> String {
+    format!("# a/ = local, b/ = upstream ({upstream_repo}@{upstream_ref})")
 }
 
 // ---------------------------------------------------------------------------
@@ -442,6 +454,42 @@ mod tests {
     // ------------------------------------------------------------------
     // emit_diff
     // ------------------------------------------------------------------
+
+    // ------------------------------------------------------------------
+    // colorize_diff comment lines
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn colorize_diff_passes_hash_line_through_without_colors() {
+        // Arrange
+        let diff = "# a/ = local, b/ = upstream (owner/repo@main)\n--- a/x\n+++ b/x\n";
+
+        // Act: colors disabled in test environment (no TTY)
+        let out = colorize_diff(diff);
+
+        // Assert: without colors the string is returned unchanged
+        assert_eq!(out, diff);
+    }
+
+    // ------------------------------------------------------------------
+    // build_diff_context_header
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn build_diff_context_header_contains_expected_parts() {
+        // Act
+        let h = build_diff_context_header("naa0yama/boilerplate-rust", "main");
+
+        // Assert
+        assert!(h.starts_with('#'), "must start with #: {h}");
+        assert!(h.contains("local"), "must mention local: {h}");
+        assert!(h.contains("upstream"), "must mention upstream: {h}");
+        assert!(
+            h.contains("naa0yama/boilerplate-rust@main"),
+            "must contain repo@ref: {h}"
+        );
+        assert!(!h.ends_with('\n'), "must not carry trailing newline: {h:?}");
+    }
 
     #[test]
     fn emit_diff_empty_writes_nothing() {

--- a/crates/gh-sync/src/sync/cli.rs
+++ b/crates/gh-sync/src/sync/cli.rs
@@ -39,6 +39,9 @@ pub struct SyncFileArgs {
     /// merged with the local manifest (local wins on conflicting paths).
     /// If the local manifest file does not exist only the upstream manifest
     /// is used.
+    ///
+    /// Example:
+    ///   gh-sync sync file --upstream-manifest naa0yama/boilerplate-rust@main:.github/gh-sync/config.yaml
     #[arg(long = "upstream-manifest", value_name = "OWNER/REPO@REF:PATH")]
     pub upstream_manifest: Option<String>,
 
@@ -82,6 +85,9 @@ pub struct SyncRepoArgs {
     /// merged with the local manifest (local wins on conflicting paths).
     /// If the local manifest file does not exist only the upstream manifest
     /// is used.
+    ///
+    /// Example:
+    ///   gh-sync sync repo --upstream-manifest naa0yama/boilerplate-rust@main:.github/gh-sync/config.yaml
     #[arg(long = "upstream-manifest", value_name = "OWNER/REPO@REF:PATH")]
     pub upstream_manifest: Option<String>,
 

--- a/crates/gh-sync/tests/fixtures/scenarios/sync_file_ci_check_drift.json
+++ b/crates/gh-sync/tests/fixtures/scenarios/sync_file_ci_check_drift.json
@@ -1,0 +1,12 @@
+[
+	{
+		"args": [
+			"api",
+			"-H",
+			"Accept: application/vnd.github.raw",
+			"repos/upstream/repo/contents/.github/ci.yml?ref=main"
+		],
+		"exit_code": 0,
+		"stdout": "upstream content\n"
+	}
+]

--- a/crates/gh-sync/tests/integration_test.rs
+++ b/crates/gh-sync/tests/integration_test.rs
@@ -57,7 +57,8 @@ fn test_cli_sync_file_help() {
         .assert()
         .success()
         .stdout(predicate::str::contains("manifest"))
-        .stdout(predicate::str::contains("dry-run"));
+        .stdout(predicate::str::contains("dry-run"))
+        .stdout(predicate::str::contains("naa0yama/boilerplate-rust@main"));
 }
 
 #[test]
@@ -68,7 +69,8 @@ fn test_cli_sync_repo_help() {
         .assert()
         .success()
         .stdout(predicate::str::contains("manifest"))
-        .stdout(predicate::str::contains("ci-check"));
+        .stdout(predicate::str::contains("ci-check"))
+        .stdout(predicate::str::contains("naa0yama/boilerplate-rust@main"));
 }
 
 #[test]
@@ -320,6 +322,46 @@ fn test_fake_gh_sync_repo_dry_run_no_drift_succeeds() {
             .or(predicate::str::contains("OK"))
             .or(predicate::str::contains("nothing")),
     );
+}
+
+/// Manifest for sync file ci-check drift tests (upstream/repo, replace strategy).
+const MANIFEST_FILE_DRIFT: &str = "\
+upstream:
+  repo: upstream/repo
+files:
+  - path: .github/ci.yml
+    strategy: replace
+";
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn test_fake_gh_sync_file_ci_check_diff_shows_context_header() {
+    // Arrange — write manifest and a local file that differs from upstream
+    let dir = tempfile::TempDir::new().unwrap();
+    let manifest = dir.path().join("config.yaml");
+    std::fs::write(&manifest, MANIFEST_FILE_DRIFT).unwrap();
+    // Create subdirectory and local file with different content than upstream
+    std::fs::create_dir_all(dir.path().join(".github")).unwrap();
+    std::fs::write(dir.path().join(".github/ci.yml"), b"local content\n").unwrap();
+
+    // Act — run `gh-sync sync file --ci-check` from the temp repo root
+    let mut cmd = cargo_bin_cmd!("gh-sync");
+    cmd.args(["sync", "file", "--ci-check", "--manifest"])
+        .arg(&manifest)
+        .current_dir(dir.path())
+        .env("PATH", path_with_fake_gh())
+        .env(
+            "GH_FAKE_SCENARIO",
+            scenario("sync_file_ci_check_drift.json"),
+        );
+
+    // Assert — exits 1 (drift detected) and diff header is present
+    cmd.assert()
+        .failure()
+        .stdout(predicate::str::contains("[DRIFT"))
+        .stdout(predicate::str::contains(
+            "# a/ = local, b/ = upstream (upstream/repo@main)",
+        ));
 }
 
 #[test]

--- a/mise.toml
+++ b/mise.toml
@@ -11,6 +11,7 @@ OPENOBSERVE_VERSION = "v0.70.3"
 "aqua:taiki-e/cargo-llvm-cov" = "0.8.5"
 "aqua:watchexec/cargo-watch" = "8.5.3"
 "cargo:cargo-sweep" = "0.8.0"
+"github:naa0yama/gh-sync" = "0.2.0"
 "github:rust-secure-code/cargo-auditable" = "0.7.4"
 actionlint = "1.7.12"
 codeql = { version = "latest", bin_path = "codeql", platforms = { linux-x64 = { asset_pattern = "codeql-linux64.zip" }, macos-arm64 = { asset_pattern = "codeql-osx64.zip" }, macos-x64 = { asset_pattern = "codeql-osx64.zip" }, windows-x64 = { asset_pattern = "codeql-win64.zip" } } }


### PR DESCRIPTION
## Summary

- `sync` モードと `ci-check` モードの unified diff 出力の直前に `# a/ = local, b/ = upstream (repo@ref)` の注釈行を 1 行追加し、どちらが手元のコードでどちらが upstream かを明示できるようにした。
- `output.rs` に `build_diff_context_header()` 関数を新設し、`colorize_diff` が `#` 始まりの行を dim スタイルで表示するよう拡張した。
- `patch_refresh` モードは `.patch` ファイル生成用途のため変更せず、diff 方向を示すコメントを 1 行追加するにとどめた。
- integration test 用の fake-gh シナリオ (`sync_file_ci_check_drift.json`) と対応するテストを追加した。

## Test plan

- [ ] `mise run test` — 全テスト通過確認
- [ ] `mise run pre-commit` — フォーマット / clippy / ast-grep / lint:gh 通過確認
- [ ] `sync file --ci-check` でドリフトがある場合に `# a/ = local, b/ = upstream (...)` が出力されること
- [ ] `NO_COLOR=1` 設定時にエスケープシーケンスなしで出力されること
- [ ] `--patch-refresh` 生成の `.patch` ファイルに注釈行が入っていないこと