### PR TITLE
ci: update tagpr action to v1.18.3

### DIFF
--- a/.github/workflows/tagpr.yaml
+++ b/.github/workflows/tagpr.yaml
@@ -54,7 +54,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - id: tagpr
-        uses: Songmu/tagpr@9d0f650553240dab1fa907eca27e3fd5b586e538 # v1.18.1
+        uses: Songmu/tagpr@9bbb945b2fb025126186661e27d55485e3fc6df6 # v1.18.3
         env:
           GITHUB_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
## Summary

- `Songmu/tagpr` を `v1.18.1` から `v1.18.3` へバージョンアップ
- `v1.18.1` には PR ノード ID をラベル ID として誤用するバグがあり、リリース PR #32 へのラベル付与で `422 Validation Failed` エラーが発生していた
- `v1.18.3` (2026-04-17 リリース) でこのバグが修正されている

## Test plan

- [ ] CI が正常に通ること
- [ ] `tagpr` ワークフローが次回実行時にラベル付与エラーなく完了すること