### PR TITLE
chore: add insertion guide markers for project-specific config blocks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ repository = "https://github.com/naa0yama/boilerplate-rust"
 # -
 [workspace.dependencies]
 # gh-sync:keep-start
+# Project-specific dependencies are listed here.
+
 # Internal crates
 gh-sync-engine = { path = "crates/gh-sync-engine" }
 gh-sync-manifest = { path = "crates/gh-sync-manifest" }

--- a/mise.toml
+++ b/mise.toml
@@ -4,6 +4,8 @@ OTEL_EXPORTER_OTLP_ENDPOINT = "http://localhost:5080/api/default"
 OPENOBSERVE_VERSION = "v0.70.3"
 
 # gh-sync:keep-start
+# Project-specific dependencies are listed here.
+
 RUST_LOG = "warn,gh_sync=trace"
 # gh-sync:keep-end
 


### PR DESCRIPTION
## 概要

- `Cargo.toml` の `[workspace.dependencies]` 内の `gh-sync:keep-start` ブロックに、プロジェクト固有の依存関係を追加する際の挿入位置を示すガイドコメントを追加した
- `mise.toml` の `gh-sync:keep-start` ブロックにも同様のガイドコメントを追加した

これらのコメントは AI (Claude) が設定追加時に正しい挿入位置を判断するためのマーカーとして機能する。

## テスト計画

- [ ] `mise run pre-commit` が通過することを確認済み
- [ ] 動作に影響する変更なし (コメント追加のみ)