### PR TITLE
feat(engine): allow preserve_markers with strategy replace

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ mise run pre-commit       # clean:sweep + fmt:check + clippy:strict + ast-grep +
 │       ├── src/
 │       │   ├── main.rs         # アプリケーションのエントリーポイント
 │       │   ├── sync/           # テンプレート同期サブコマンド
+│       │   │   ├── detect.rs   # fork/template 親リポジトリの自動検出
 │       │   │   └── runner.rs   # GhRunner トレイト (gh CLI 呼び出し抽象化)
 │       │   └── init/           # init サブコマンド
 │       ├── tests/

--- a/crates/gh-sync-engine/src/mode/ci_check.rs
+++ b/crates/gh-sync-engine/src/mode/ci_check.rs
@@ -156,7 +156,20 @@ fn evaluate_drift(
                 };
 
             let expected = if rule.strategy == Strategy::Replace {
-                upstream
+                if rule.preserve_markers.unwrap_or(false) {
+                    match strategy::replace::apply_with_markers(&upstream, local_bytes) {
+                        StrategyResult::Changed { content } => content,
+                        StrategyResult::Unchanged => {
+                            local_bytes.map(<[u8]>::to_vec).unwrap_or(upstream)
+                        }
+                        StrategyResult::Error(msg) => {
+                            return (false, format!("marker error: {msg}"), String::new(), true);
+                        }
+                        _ => upstream,
+                    }
+                } else {
+                    upstream
+                }
             } else {
                 // Apply patch to get expected content
                 let patch_path = manifest::resolve_patch_path(rule);
@@ -460,6 +473,71 @@ mod tests {
         assert_eq!(extract_pr_number("refs/heads/main"), None);
         assert_eq!(extract_pr_number("refs/pull/abc/merge"), None);
         assert_eq!(extract_pr_number("refs/pull/123/head"), None);
+    }
+
+    // ------------------------------------------------------------------
+    // replace + preserve_markers
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn ci_check_replace_preserve_markers_reports_up_to_date_when_only_blocks_differ() {
+        // Arrange: local has a marker block; upstream has no markers (just baseline).
+        // After merge the expected = upstream_stripped + local_blocks = local → no drift.
+        let dir = tempfile::tempdir().unwrap();
+        let marker_block = b"# gh-sync:keep-start\nb = local\n# gh-sync:keep-end\n";
+        let local_content = [b"a = 1\n".as_slice(), marker_block.as_slice()].concat();
+        std::fs::write(dir.path().join("cfg.toml"), &local_content).unwrap();
+
+        let manifest = make_manifest(vec![Rule {
+            path: String::from("cfg.toml"),
+            strategy: Strategy::Replace,
+            source: None,
+            patch: None,
+            preserve_markers: Some(true),
+        }]);
+        let fetcher = MockFetcher::content(b"a = 1\n".to_vec());
+        let runner = MockPatchRunner::success(vec![]);
+        let mut buf: Vec<u8> = Vec::new();
+
+        // Act
+        let code = run(&manifest, dir.path(), &fetcher, &runner, &mut buf).unwrap();
+
+        // Assert
+        let out = String::from_utf8(buf).unwrap();
+        assert!(matches!(code, ExitCode::SUCCESS), "expected SUCCESS: {out}");
+        assert!(out.contains("[OK"), "expected OK (no drift): {out}");
+    }
+
+    #[cfg_attr(
+        miri,
+        ignore = "spawns gh process via maybe_post_pr_comment when GITHUB_ACTIONS is set"
+    )]
+    #[test]
+    fn ci_check_replace_preserve_markers_reports_drift_when_non_marker_differs() {
+        // Arrange: upstream changed; local has stale non-marker content.
+        let dir = tempfile::tempdir().unwrap();
+        let marker_block = b"# gh-sync:keep-start\nb = local\n# gh-sync:keep-end\n";
+        let local_content = [b"a = old\n".as_slice(), marker_block.as_slice()].concat();
+        std::fs::write(dir.path().join("cfg.toml"), &local_content).unwrap();
+
+        let manifest = make_manifest(vec![Rule {
+            path: String::from("cfg.toml"),
+            strategy: Strategy::Replace,
+            source: None,
+            patch: None,
+            preserve_markers: Some(true),
+        }]);
+        let fetcher = MockFetcher::content(b"a = new\n".to_vec());
+        let runner = MockPatchRunner::success(vec![]);
+        let mut buf: Vec<u8> = Vec::new();
+
+        // Act
+        let code = run(&manifest, dir.path(), &fetcher, &runner, &mut buf).unwrap();
+
+        // Assert
+        let out = String::from_utf8(buf).unwrap();
+        assert!(matches!(code, ExitCode::FAILURE), "expected FAILURE: {out}");
+        assert!(out.contains("[DRIFT"), "expected DRIFT: {out}");
     }
 
     // ------------------------------------------------------------------

--- a/crates/gh-sync-engine/src/mode/sync.rs
+++ b/crates/gh-sync-engine/src/mode/sync.rs
@@ -84,7 +84,14 @@ pub fn run(
                     },
                     Ok(FetchResult::Content(upstream)) => {
                         if rule.strategy == Strategy::Replace {
-                            strategy::replace::apply(&upstream, local_bytes.as_deref())
+                            if rule.preserve_markers.unwrap_or(false) {
+                                strategy::replace::apply_with_markers(
+                                    &upstream,
+                                    local_bytes.as_deref(),
+                                )
+                            } else {
+                                strategy::replace::apply(&upstream, local_bytes.as_deref())
+                            }
                         } else {
                             strategy::create_only::apply(&upstream, local_bytes.is_some())
                         }
@@ -551,4 +558,47 @@ mod tests {
     }
 
     fn _use_dir(_dir: &TempDir) {}
+
+    // ------------------------------------------------------------------
+    // replace + preserve_markers
+    // ------------------------------------------------------------------
+
+    #[cfg_attr(
+        miri,
+        ignore = "spawns diff process via unified_diff for Changed results"
+    )]
+    #[test]
+    fn sync_replace_preserve_markers_writes_merged_content() {
+        // Arrange: local file has a marker block that should survive after sync.
+        let dir = tempfile::tempdir().unwrap();
+        let marker_block = b"# gh-sync:keep-start\nb = local\n# gh-sync:keep-end\n";
+        let local_content = [b"a = old\n".as_slice(), marker_block.as_slice()].concat();
+        std::fs::write(dir.path().join("cfg.toml"), &local_content).unwrap();
+
+        let manifest = make_manifest(vec![Rule {
+            path: String::from("cfg.toml"),
+            strategy: Strategy::Replace,
+            source: None,
+            patch: None,
+            preserve_markers: Some(true),
+        }]);
+        // Upstream has only the non-marker line updated.
+        let fetcher = MockFetcher::content(b"a = new\n".to_vec());
+        let runner = MockPatchRunner::success(vec![]);
+        let mut buf: Vec<u8> = Vec::new();
+
+        // Act
+        let (code, actions) = run(&manifest, dir.path(), &fetcher, &runner, &mut buf).unwrap();
+        apply_outcomes(actions).unwrap();
+
+        // Assert
+        let out = String::from_utf8(buf).unwrap();
+        assert!(matches!(code, ExitCode::SUCCESS), "expected SUCCESS: {out}");
+        let written = std::fs::read(dir.path().join("cfg.toml")).unwrap();
+        let expected: Vec<u8> = [b"a = new\n".as_slice(), marker_block.as_slice()].concat();
+        assert_eq!(
+            written, expected,
+            "marker block must be preserved after replace+preserve_markers sync"
+        );
+    }
 }

--- a/crates/gh-sync-engine/src/strategy/replace.rs
+++ b/crates/gh-sync-engine/src/strategy/replace.rs
@@ -1,4 +1,5 @@
 use super::StrategyResult;
+use super::markers::{merge_marker_blocks, strip_marker_blocks};
 
 /// Apply the `replace` strategy.
 ///
@@ -14,12 +15,129 @@ pub fn apply(upstream: &[u8], local: Option<&[u8]>) -> StrategyResult {
     }
 }
 
+/// Apply the `replace` strategy with marker-block preservation.
+///
+/// Strips marker blocks from both sides, replaces non-marker content with
+/// upstream, then re-inserts the local marker blocks into the result.
+#[must_use]
+pub fn apply_with_markers(upstream: &[u8], local: Option<&[u8]>) -> StrategyResult {
+    let upstream_stripped = match strip_marker_blocks(upstream) {
+        Ok((s, _)) => s,
+        Err(e) => {
+            return StrategyResult::Error(format!("invalid marker block (upstream): {e}"));
+        }
+    };
+    let local_blocks = match local {
+        Some(b) => match strip_marker_blocks(b) {
+            Ok((_, blocks)) => blocks,
+            Err(e) => {
+                return StrategyResult::Error(format!("invalid marker block (local): {e}"));
+            }
+        },
+        None => Vec::new(),
+    };
+    let merged = merge_marker_blocks(&upstream_stripped, &local_blocks);
+    if local == Some(merged.as_slice()) {
+        StrategyResult::Unchanged
+    } else {
+        StrategyResult::Changed { content: merged }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used)]
     #![allow(clippy::panic)]
 
     use super::*;
+
+    // ------------------------------------------------------------------
+    // apply_with_markers
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn apply_with_markers_local_none_returns_changed() {
+        let upstream = b"a = 1\nb = 2\n";
+        let result = apply_with_markers(upstream, None);
+        assert!(
+            matches!(result, StrategyResult::Changed { ref content } if content == upstream),
+            "expected Changed when local is None"
+        );
+    }
+
+    #[test]
+    fn apply_with_markers_no_markers_matches_apply() {
+        // Without marker blocks, apply_with_markers must behave like apply.
+        let upstream = b"new\n";
+        let local = b"old\n";
+        let result = apply_with_markers(upstream, Some(local));
+        assert!(
+            matches!(result, StrategyResult::Changed { ref content } if content == upstream),
+            "expected Changed equal to upstream when no markers"
+        );
+    }
+
+    #[test]
+    fn apply_with_markers_local_blocks_preserved_when_upstream_changed() {
+        // Arrange: upstream has no markers; local wraps a value in a marker block.
+        let upstream = b"a = upstream\n";
+        let local = b"a = upstream\n# gh-sync:keep-start\nb = local\n# gh-sync:keep-end\n";
+        // After strip(upstream) = "a = upstream\n"; local blocks = the b=local block.
+        // merged = "a = upstream\n" + block → same as local → Unchanged.
+        let result = apply_with_markers(upstream, Some(local));
+        assert!(
+            matches!(result, StrategyResult::Unchanged),
+            "expected Unchanged when only marker blocks differ from bare upstream"
+        );
+    }
+
+    #[test]
+    fn apply_with_markers_changed_when_non_marker_differs() {
+        let upstream = b"a = new\n";
+        let marker_block = b"# gh-sync:keep-start\nb = local\n# gh-sync:keep-end\n";
+        let local = [b"a = old\n".as_slice(), marker_block.as_slice()].concat();
+        let result = apply_with_markers(upstream, Some(&local));
+        // expected content = upstream + marker block
+        let expected: Vec<u8> = [b"a = new\n".as_slice(), marker_block.as_slice()].concat();
+        assert!(
+            matches!(result, StrategyResult::Changed { ref content } if *content == expected),
+            "expected Changed with upstream content plus local marker block"
+        );
+    }
+
+    #[test]
+    fn apply_with_markers_unchanged_when_stripped_equal() {
+        // local == merge_marker_blocks(upstream_stripped, local_blocks) → Unchanged
+        let upstream = b"a = 1\n";
+        let local = b"a = 1\n";
+        let result = apply_with_markers(upstream, Some(local));
+        assert!(
+            matches!(result, StrategyResult::Unchanged),
+            "expected Unchanged when content already matches"
+        );
+    }
+
+    #[test]
+    fn apply_with_markers_unbalanced_local_returns_error() {
+        let upstream = b"a = 1\n";
+        let local = b"# gh-sync:keep-start\na = 1\n"; // missing keep-end
+        let result = apply_with_markers(upstream, Some(local));
+        assert!(
+            matches!(result, StrategyResult::Error(ref msg) if msg.contains("local")),
+            "expected Error for unbalanced local markers"
+        );
+    }
+
+    #[test]
+    fn apply_with_markers_unbalanced_upstream_returns_error() {
+        let upstream = b"# gh-sync:keep-start\na = 1\n"; // missing keep-end
+        let local = b"a = 1\n";
+        let result = apply_with_markers(upstream, Some(local));
+        assert!(
+            matches!(result, StrategyResult::Error(ref msg) if msg.contains("upstream")),
+            "expected Error for unbalanced upstream markers"
+        );
+    }
 
     #[test]
     fn local_none_returns_changed() {

--- a/crates/gh-sync-manifest/src/manifest.rs
+++ b/crates/gh-sync-manifest/src/manifest.rs
@@ -397,8 +397,8 @@ pub struct Rule {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub patch: Option<String>,
     /// When `true`, lines enclosed by `gh-sync:keep-start` / `gh-sync:keep-end`
-    /// marker comments are excluded from drift detection and patch generation.
-    /// Only valid with `strategy: patch`.
+    /// marker comments are excluded from drift detection and preserved on write-back.
+    /// Valid with `strategy: patch` or `strategy: replace`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub preserve_markers: Option<bool>,
 }
@@ -597,11 +597,13 @@ pub fn validate_schema(manifest: &Manifest) -> Result<(), SyncError> {
                 }
             }
         }
-        if rule.strategy != Strategy::Patch && rule.preserve_markers.is_some() {
+        if !matches!(rule.strategy, Strategy::Patch | Strategy::Replace)
+            && rule.preserve_markers.is_some()
+        {
             errors.push(ValidationError::rule(
                 i,
                 "preserve_markers",
-                "field only allowed for strategy 'patch'",
+                "field only allowed for strategy 'patch' or 'replace'",
             ));
         }
     }
@@ -1238,6 +1240,112 @@ files:
     patch: foo.patch
 ",
             "patch",
+        );
+    }
+
+    // --- validate_schema: preserve_markers ---
+
+    #[cfg_attr(miri, ignore = "libyml ptr_offset_from UB under Miri")]
+    #[test]
+    fn validate_schema_accepts_replace_with_preserve_markers() {
+        expect_schema_ok(
+            r"
+upstream:
+  repo: owner/repo
+files:
+  - path: foo.txt
+    strategy: replace
+    preserve_markers: true
+",
+        );
+    }
+
+    #[cfg_attr(miri, ignore = "libyml ptr_offset_from UB under Miri")]
+    #[test]
+    fn validate_schema_accepts_patch_with_preserve_markers() {
+        expect_schema_ok(
+            r"
+upstream:
+  repo: owner/repo
+files:
+  - path: foo.txt
+    strategy: patch
+    preserve_markers: true
+",
+        );
+    }
+
+    #[cfg_attr(miri, ignore = "libyml ptr_offset_from UB under Miri")]
+    #[test]
+    fn validate_schema_rejects_create_only_with_preserve_markers() {
+        expect_schema_error(
+            r"
+upstream:
+  repo: owner/repo
+files:
+  - path: foo.txt
+    strategy: create_only
+    preserve_markers: true
+",
+            "preserve_markers",
+        );
+    }
+
+    #[cfg_attr(miri, ignore = "libyml ptr_offset_from UB under Miri")]
+    #[test]
+    fn validate_schema_rejects_delete_with_preserve_markers() {
+        expect_schema_error(
+            r"
+upstream:
+  repo: owner/repo
+files:
+  - path: foo.txt
+    strategy: delete
+    preserve_markers: true
+",
+            "preserve_markers",
+        );
+    }
+
+    #[cfg_attr(miri, ignore = "libyml ptr_offset_from UB under Miri")]
+    #[test]
+    fn validate_schema_rejects_ignore_with_preserve_markers() {
+        expect_schema_error(
+            r"
+upstream:
+  repo: owner/repo
+files:
+  - path: foo.txt
+    strategy: ignore
+    preserve_markers: true
+",
+            "preserve_markers",
+        );
+    }
+
+    #[cfg_attr(miri, ignore = "libyml ptr_offset_from UB under Miri")]
+    #[test]
+    fn validate_schema_error_message_mentions_patch_or_replace() {
+        let m = manifest_from_yaml(
+            r"
+upstream:
+  repo: owner/repo
+files:
+  - path: foo.txt
+    strategy: delete
+    preserve_markers: true
+",
+        );
+        let Err(SyncError::Validation(errors)) = validate_schema(&m) else {
+            panic!("expected Validation error");
+        };
+        let msg = errors
+            .iter()
+            .find(|e| e.field == "preserve_markers")
+            .map_or("", |e| e.message.as_str());
+        assert!(
+            msg.contains("patch") && msg.contains("replace"),
+            "error message should mention both 'patch' and 'replace': {msg}"
         );
     }
 

--- a/crates/gh-sync/src/init/mod.rs
+++ b/crates/gh-sync/src/init/mod.rs
@@ -18,6 +18,8 @@ use std::process::ExitCode;
 use anyhow::Context as _;
 use cli::InitArgs;
 
+use crate::sync::detect;
+use crate::sync::runner::{GhRunner, SystemGhRunner};
 use crate::sync::upstream::GhFetcher;
 
 // ---------------------------------------------------------------------------
@@ -71,12 +73,20 @@ fn write_file(path: &Path, content: &str) -> anyhow::Result<()> {
 
 /// Resolve the repository argument, prompting interactively when not provided.
 ///
+/// `default_hint` is pre-filled into the interactive prompt when `--repo` is
+/// absent, so the user can simply press Enter to accept the detected value.
+///
 /// # Errors
 ///
 /// Returns an error when the repo format is invalid, the prompt is cancelled,
 /// or `--repo` is absent in non-interactive mode.
 #[cfg_attr(coverage_nightly, coverage(off))]
-fn resolve_repo(args: &InitArgs, prompt: &str, non_tty_example: &str) -> anyhow::Result<String> {
+fn resolve_repo(
+    args: &InitArgs,
+    prompt: &str,
+    non_tty_example: &str,
+    default_hint: Option<&str>,
+) -> anyhow::Result<String> {
     match &args.repo {
         Some(r) => {
             validate_repo_format(r)?;
@@ -84,10 +94,13 @@ fn resolve_repo(args: &InitArgs, prompt: &str, non_tty_example: &str) -> anyhow:
         }
         None => {
             if io::stdin().is_terminal() {
-                dialoguer::Input::<String>::new()
-                    .with_prompt(prompt)
-                    .validate_with(|input: &String| -> Result<(), &str> {
-                        if is_valid_repo(input) {
+                let mut input = dialoguer::Input::<String>::new().with_prompt(prompt);
+                if let Some(hint) = default_hint {
+                    input = input.default(hint.to_owned()).show_default(true);
+                }
+                input
+                    .validate_with(|i: &String| -> Result<(), &str> {
+                        if is_valid_repo(i) {
                             Ok(())
                         } else {
                             Err("must be owner/name format (e.g. naa0yama/boilerplate-rust)")
@@ -192,7 +205,7 @@ fn confirm_overwrite_with_diff(
 /// Writes files appropriate to the selected mode (upstream or downstream).
 #[cfg_attr(coverage_nightly, coverage(off))]
 pub fn execute(args: &InitArgs) -> ExitCode {
-    match run(args, &GhFetcher) {
+    match run(args, &GhFetcher, &SystemGhRunner) {
         Ok(()) => ExitCode::SUCCESS,
         Err(e) => {
             tracing::error!("init failed: {e:#}");
@@ -210,11 +223,12 @@ pub fn execute(args: &InitArgs) -> ExitCode {
 pub fn run(
     args: &InitArgs,
     fetcher: &dyn crate::sync::upstream::UpstreamFetcher,
+    runner: &dyn GhRunner,
 ) -> anyhow::Result<()> {
     if args.upstream {
-        run_upstream(args, fetcher)
+        run_upstream(args, fetcher, runner)
     } else {
-        run_downstream(args, fetcher)
+        run_downstream(args, fetcher, runner)
     }
 }
 
@@ -228,6 +242,7 @@ pub fn run(
 fn run_upstream(
     args: &InitArgs,
     fetcher: &dyn crate::sync::upstream::UpstreamFetcher,
+    runner: &dyn GhRunner,
 ) -> anyhow::Result<()> {
     let output = args
         .output
@@ -258,12 +273,14 @@ fn run_upstream(
     }
 
     // -----------------------------------------------------------------------
-    // 2. Determine repo
+    // 2. Determine repo (detect current repo as default hint)
     // -----------------------------------------------------------------------
+    let hint = detect::detect_repo_hint(runner, false);
     let repo = resolve_repo(
         args,
         "Upstream repository (owner/name)",
         "gh-sync init --upstream --repo owner/name --select",
+        hint.as_deref(),
     )?;
 
     // -----------------------------------------------------------------------
@@ -314,14 +331,17 @@ fn run_upstream(
 fn run_downstream(
     args: &InitArgs,
     fetcher: &dyn crate::sync::upstream::UpstreamFetcher,
+    runner: &dyn GhRunner,
 ) -> anyhow::Result<()> {
     // -----------------------------------------------------------------------
-    // 1. Determine repo
+    // 1. Determine repo (detect fork/template parent as default hint)
     // -----------------------------------------------------------------------
+    let hint = detect::detect_repo_hint(runner, true);
     let repo = resolve_repo(
         args,
         "Upstream template repository (owner/name)",
         "gh-sync init --downstream --repo owner/name",
+        hint.as_deref(),
     )?;
 
     // -----------------------------------------------------------------------

--- a/crates/gh-sync/src/init/schema.rs
+++ b/crates/gh-sync/src/init/schema.rs
@@ -320,6 +320,10 @@ pub const SCHEMA_JSON: &str = r#"{
             "type": "string",
             "minLength": 1,
             "description": "Explicit patch file path (patch strategy only; defaults to .github/gh-sync/patches/<path>.patch)"
+          },
+          "preserve_markers": {
+            "type": "boolean",
+            "description": "Preserve gh-sync:keep-start/keep-end marker blocks from the local file. Only used when strategy is 'patch' or 'replace'."
           }
         }
       }

--- a/crates/gh-sync/src/init/skill.rs
+++ b/crates/gh-sync/src/init/skill.rs
@@ -55,16 +55,23 @@ JSON / JSONC (`//` comment style):
 
 ## Enabling in the Manifest
 
-Add `preserve_markers: true` to each `strategy: patch` rule that uses marker
-blocks. This field is set in the upstream `gh-sync.yaml` manifest, not in a
-local overlay.
+Add `preserve_markers: true` to any `strategy: patch` or `strategy: replace`
+rule that uses marker blocks. This field is set in the upstream `gh-sync.yaml`
+manifest, not in a local overlay.
 
 ```yaml
 files:
   - path: Cargo.toml
     strategy: patch
     preserve_markers: true
+  - path: .vscode/launch.json
+    strategy: replace
+    preserve_markers: true
 ```
+
+Use `strategy: replace` when you only need marker preservation with no patch
+file. Use `strategy: patch` when you also need a diff-based patch applied on
+top of the upstream content.
 
 ## Behavior
 
@@ -116,6 +123,8 @@ RUST_LOG = \"warn,gh_sync=trace\"
 
 - `preserve_markers: true` is opt-in per rule. Rules without it treat marker
   comment lines as ordinary content.
+- Valid with `strategy: patch` or `strategy: replace`. Other strategies
+  (`create_only`, `delete`, `ignore`) reject this field.
 - Nested marker blocks are not supported and produce an error.
 - Use `strategy: ignore` to skip syncing an entire file rather than
   protecting specific regions within it.

--- a/crates/gh-sync/src/sync/detect.rs
+++ b/crates/gh-sync/src/sync/detect.rs
@@ -1,0 +1,572 @@
+//! Auto-detection of the fork / template parent for the current repository.
+//!
+//! Queries `gh api repos/{owner}/{repo}` and inspects the `parent` (fork) and
+//! `template_repository` fields to determine if the current repo was derived
+//! from an upstream template.  The result is used by `sync file`, `sync repo`,
+//! and `init` to offer the upstream as a default `--upstream-manifest` value.
+
+use anyhow::Context as _;
+
+use crate::sync::runner::GhRunner;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// Whether the detected upstream relationship is a fork or a template clone.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParentSource {
+    Fork,
+    Template,
+}
+
+impl ParentSource {
+    pub const fn label(&self) -> &'static str {
+        match self {
+            Self::Fork => "fork",
+            Self::Template => "template",
+        }
+    }
+}
+
+/// An upstream repository that is the fork or template parent of the current repo.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpstreamParent {
+    /// `owner/name` format, e.g. `"naa0yama/boilerplate-rust"`.
+    pub full_name: String,
+    /// Default branch of the parent, e.g. `"main"`.
+    pub default_branch: String,
+    pub source: ParentSource,
+}
+
+/// Decision made by [`decide_upstream_manifest`].
+#[derive(Debug, PartialEq, Eq)]
+pub enum UpstreamDecision {
+    /// `--upstream-manifest` was explicitly specified.
+    Explicit(String),
+    /// No upstream manifest should be used (local-only flow).
+    LocalOnly,
+    /// Detection succeeded and user confirmed; contains the composed reference.
+    UseDetected(String),
+}
+
+// ---------------------------------------------------------------------------
+// Internal deserialization types
+// ---------------------------------------------------------------------------
+
+#[derive(serde::Deserialize)]
+struct RepoMeta {
+    fork: bool,
+    parent: Option<RepoRef>,
+    template_repository: Option<RepoRef>,
+}
+
+#[derive(serde::Deserialize)]
+struct RepoRef {
+    full_name: String,
+    default_branch: String,
+}
+
+// ---------------------------------------------------------------------------
+// Detection functions
+// ---------------------------------------------------------------------------
+
+/// Return the current repository in `owner/name` format.
+///
+/// Checks `GITHUB_REPOSITORY` environment variable first (fast path for
+/// GitHub Actions), then falls back to `gh repo view`.
+///
+/// # Errors
+///
+/// Returns an error when the `gh` CLI call fails or returns a non-zero exit
+/// code.
+#[allow(clippy::module_name_repetitions)]
+pub fn detect_current_repo(runner: &dyn GhRunner) -> anyhow::Result<String> {
+    if let Ok(v) = std::env::var("GITHUB_REPOSITORY")
+        && !v.is_empty()
+    {
+        return Ok(v);
+    }
+
+    let out = runner
+        .run(
+            &[
+                "repo",
+                "view",
+                "--json",
+                "nameWithOwner",
+                "--jq",
+                ".nameWithOwner",
+            ],
+            None,
+        )
+        .context("failed to spawn `gh repo view`")?;
+
+    if !out.success() {
+        anyhow::bail!(
+            "`gh repo view` failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    Ok(String::from_utf8_lossy(&out.stdout).trim().to_owned())
+}
+
+/// Query GitHub and return the upstream parent of `current_repo`, if any.
+///
+/// Priority: fork parent (`parent` field) takes precedence over template
+/// (`template_repository`).  Returns `Ok(None)` when neither is present.
+///
+/// # Errors
+///
+/// Returns an error when the `gh api` call fails, returns a non-zero exit
+/// code, or the response cannot be parsed.
+#[allow(clippy::module_name_repetitions)]
+pub fn detect_upstream_parent(
+    runner: &dyn GhRunner,
+    current_repo: &str,
+) -> anyhow::Result<Option<UpstreamParent>> {
+    let url = format!("repos/{current_repo}");
+    let out = runner
+        .run(&["api", &url], None)
+        .context("failed to spawn `gh api`")?;
+
+    if !out.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        anyhow::bail!("`gh api {url}` failed: {stderr}");
+    }
+
+    let meta: RepoMeta =
+        serde_json::from_slice(&out.stdout).context("failed to parse repository metadata JSON")?;
+
+    // Fork parent takes priority over template.
+    if let Some(p) = meta.fork.then_some(meta.parent).flatten() {
+        return Ok(Some(UpstreamParent {
+            full_name: p.full_name,
+            default_branch: p.default_branch,
+            source: ParentSource::Fork,
+        }));
+    }
+
+    if let Some(t) = meta.template_repository {
+        return Ok(Some(UpstreamParent {
+            full_name: t.full_name,
+            default_branch: t.default_branch,
+            source: ParentSource::Template,
+        }));
+    }
+
+    Ok(None)
+}
+
+// ---------------------------------------------------------------------------
+// Pure decision logic (unit-testable without I/O)
+// ---------------------------------------------------------------------------
+
+/// Decide which upstream manifest reference to use.
+///
+/// - `explicit` — value of `--upstream-manifest` CLI flag.
+/// - `yes` — `--yes` flag; skip detection prompt.
+/// - `is_tty` — whether stdin is a terminal.
+/// - `detected` — result of auto-detection (may be `None`).
+/// - `manifest_path` — local manifest path used to compose the suggestion.
+/// - `confirm` — closure called with the suggested reference string; returns
+///   `true` when the user accepts.
+pub fn decide_upstream_manifest(
+    explicit: Option<&str>,
+    yes: bool,
+    is_tty: bool,
+    detected: Option<&UpstreamParent>,
+    manifest_path: &str,
+    confirm: &dyn Fn(&str) -> bool,
+) -> UpstreamDecision {
+    if let Some(s) = explicit {
+        return UpstreamDecision::Explicit(s.to_owned());
+    }
+
+    if yes || !is_tty {
+        return UpstreamDecision::LocalOnly;
+    }
+
+    let Some(parent) = detected else {
+        return UpstreamDecision::LocalOnly;
+    };
+
+    let suggested = format!(
+        "{}@{}:{}",
+        parent.full_name, parent.default_branch, manifest_path
+    );
+
+    if confirm(&suggested) {
+        UpstreamDecision::UseDetected(suggested)
+    } else {
+        UpstreamDecision::LocalOnly
+    }
+}
+
+// ---------------------------------------------------------------------------
+// I/O orchestration (coverage(off) — thin shell around pure logic)
+// ---------------------------------------------------------------------------
+
+/// Try to detect parent; warn and return `None` on any error.
+fn try_detect_parent(runner: &dyn GhRunner) -> Option<UpstreamParent> {
+    let repo = match detect_current_repo(runner) {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!("could not determine current repository: {e:#}");
+            return None;
+        }
+    };
+
+    match detect_upstream_parent(runner, &repo) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!("could not detect upstream parent for '{repo}': {e:#}");
+            None
+        }
+    }
+}
+
+/// Compute the effective `--upstream-manifest` value, running detection and
+/// prompting the user when appropriate.
+///
+/// Returns `Some(reference)` when an upstream should be used, `None` for
+/// local-only mode.
+///
+/// # Coverage
+///
+/// Excluded from coverage because it performs I/O (spawns `gh`, shows a
+/// `dialoguer` prompt).
+#[cfg_attr(coverage_nightly, coverage(off))]
+pub fn resolve_effective_upstream(
+    explicit: Option<&str>,
+    yes: bool,
+    manifest_path: &std::path::Path,
+    runner: &dyn GhRunner,
+) -> Option<String> {
+    use std::io::IsTerminal as _;
+
+    // Fast paths that require no detection.
+    if let Some(s) = explicit {
+        return Some(s.to_owned());
+    }
+    if yes || !std::io::stdin().is_terminal() {
+        return None;
+    }
+
+    let parent = try_detect_parent(runner)?;
+    let manifest_path_str = manifest_path.to_string_lossy();
+
+    let decision = decide_upstream_manifest(
+        None,
+        false,
+        true,
+        Some(&parent),
+        &manifest_path_str,
+        &|suggested| {
+            let prompt = format!(
+                "Detected {} parent: {}@{}\nUse {} as upstream-manifest?",
+                parent.source.label(),
+                parent.full_name,
+                parent.default_branch,
+                suggested,
+            );
+            dialoguer::Confirm::new()
+                .with_prompt(prompt)
+                .default(false)
+                .interact()
+                .unwrap_or(false)
+        },
+    );
+
+    match decision {
+        UpstreamDecision::UseDetected(s) => Some(s),
+        _ => None,
+    }
+}
+
+/// Compute a default hint for `--repo` in `init` commands.
+///
+/// - For `--upstream` mode (`for_downstream = false`): returns the current
+///   repo's own name.
+/// - For `--downstream` mode (`for_downstream = true`): returns the parent
+///   repo's `full_name`.
+///
+/// Returns `None` when detection fails or no parent is found (for downstream),
+/// or when stdin is not a TTY.
+#[allow(clippy::module_name_repetitions)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+pub fn detect_repo_hint(runner: &dyn GhRunner, for_downstream: bool) -> Option<String> {
+    use std::io::IsTerminal as _;
+
+    if !std::io::stdin().is_terminal() {
+        return None;
+    }
+
+    if for_downstream {
+        try_detect_parent(runner).map(|p| p.full_name)
+    } else {
+        detect_current_repo(runner).ok()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::panic)]
+
+    use std::collections::VecDeque;
+    use std::sync::Mutex;
+
+    use crate::sync::runner::{GhOutput, GhRunner};
+
+    use super::*;
+
+    // -----------------------------------------------------------------------
+    // Minimal MockGhRunner for detect.rs tests
+    // -----------------------------------------------------------------------
+
+    struct MockGhRunner {
+        queue: Mutex<VecDeque<GhOutput>>,
+    }
+
+    impl MockGhRunner {
+        fn new(responses: Vec<GhOutput>) -> Self {
+            Self {
+                queue: Mutex::new(responses.into()),
+            }
+        }
+
+        fn ok(stdout: impl Into<Vec<u8>>) -> Self {
+            Self::new(vec![GhOutput {
+                exit_code: Some(0),
+                stdout: stdout.into(),
+                stderr: vec![],
+            }])
+        }
+
+        fn fail(stderr: impl Into<Vec<u8>>) -> Self {
+            Self::new(vec![GhOutput {
+                exit_code: Some(1),
+                stdout: vec![],
+                stderr: stderr.into(),
+            }])
+        }
+    }
+
+    impl GhRunner for MockGhRunner {
+        fn run(&self, _args: &[&str], _stdin: Option<&[u8]>) -> anyhow::Result<GhOutput> {
+            self.queue
+                .lock()
+                .unwrap()
+                .pop_front()
+                .ok_or_else(|| anyhow::anyhow!("MockGhRunner: no more responses queued"))
+        }
+    }
+
+    fn fork_json(parent_full_name: &str, parent_default_branch: &str) -> Vec<u8> {
+        serde_json::to_vec(&serde_json::json!({
+            "fork": true,
+            "parent": {
+                "full_name": parent_full_name,
+                "default_branch": parent_default_branch,
+            },
+            "template_repository": null
+        }))
+        .unwrap()
+    }
+
+    fn template_json(tmpl_full_name: &str, tmpl_default_branch: &str) -> Vec<u8> {
+        serde_json::to_vec(&serde_json::json!({
+            "fork": false,
+            "parent": null,
+            "template_repository": {
+                "full_name": tmpl_full_name,
+                "default_branch": tmpl_default_branch,
+            }
+        }))
+        .unwrap()
+    }
+
+    fn no_parent_json() -> Vec<u8> {
+        serde_json::to_vec(&serde_json::json!({
+            "fork": false,
+            "parent": null,
+            "template_repository": null
+        }))
+        .unwrap()
+    }
+
+    // -----------------------------------------------------------------------
+    // detect_upstream_parent
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn detects_fork_parent() {
+        let runner = MockGhRunner::ok(fork_json("upstream/repo", "main"));
+        let result = detect_upstream_parent(&runner, "owner/fork").unwrap();
+        let parent = result.unwrap();
+        assert_eq!(parent.full_name, "upstream/repo");
+        assert_eq!(parent.default_branch, "main");
+        assert_eq!(parent.source, ParentSource::Fork);
+    }
+
+    #[test]
+    fn detects_template_parent() {
+        let runner = MockGhRunner::ok(template_json("tmpl/repo", "main"));
+        let result = detect_upstream_parent(&runner, "owner/clone").unwrap();
+        let parent = result.unwrap();
+        assert_eq!(parent.full_name, "tmpl/repo");
+        assert_eq!(parent.default_branch, "main");
+        assert_eq!(parent.source, ParentSource::Template);
+    }
+
+    #[test]
+    fn returns_none_when_no_parent() {
+        let runner = MockGhRunner::ok(no_parent_json());
+        let result = detect_upstream_parent(&runner, "owner/standalone").unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn fork_true_but_null_parent_falls_back_to_template() {
+        let json = serde_json::to_vec(&serde_json::json!({
+            "fork": true,
+            "parent": null,
+            "template_repository": {
+                "full_name": "tmpl/repo",
+                "default_branch": "main",
+            }
+        }))
+        .unwrap();
+        let runner = MockGhRunner::ok(json);
+        let result = detect_upstream_parent(&runner, "owner/fork").unwrap();
+        let parent = result.unwrap();
+        assert_eq!(parent.full_name, "tmpl/repo");
+        assert_eq!(parent.source, ParentSource::Template);
+    }
+
+    #[test]
+    fn fork_true_both_null_returns_none() {
+        let json = serde_json::to_vec(&serde_json::json!({
+            "fork": true,
+            "parent": null,
+            "template_repository": null
+        }))
+        .unwrap();
+        let runner = MockGhRunner::ok(json);
+        let result = detect_upstream_parent(&runner, "owner/fork").unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn gh_api_non_zero_returns_error() {
+        let runner = MockGhRunner::fail(b"HTTP 404: Not Found".as_ref());
+        let result = detect_upstream_parent(&runner, "owner/repo");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn invalid_json_returns_error() {
+        let runner = MockGhRunner::ok(b"not-json".as_ref());
+        let result = detect_upstream_parent(&runner, "owner/repo");
+        assert!(result.is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // decide_upstream_manifest (pure function — no I/O)
+    // -----------------------------------------------------------------------
+
+    fn sample_parent() -> UpstreamParent {
+        UpstreamParent {
+            full_name: String::from("upstream/repo"),
+            default_branch: String::from("main"),
+            source: ParentSource::Template,
+        }
+    }
+
+    #[test]
+    fn explicit_takes_priority() {
+        let decision = decide_upstream_manifest(
+            Some("explicit/repo@main:config.yaml"),
+            false,
+            true,
+            Some(&sample_parent()),
+            "config.yaml",
+            &|_| panic!("should not be called"),
+        );
+        assert_eq!(
+            decision,
+            UpstreamDecision::Explicit(String::from("explicit/repo@main:config.yaml"))
+        );
+    }
+
+    #[test]
+    fn yes_flag_gives_local_only() {
+        let decision = decide_upstream_manifest(
+            None,
+            true,
+            true,
+            Some(&sample_parent()),
+            "config.yaml",
+            &|_| panic!("should not be called"),
+        );
+        assert_eq!(decision, UpstreamDecision::LocalOnly);
+    }
+
+    #[test]
+    fn non_tty_gives_local_only() {
+        let decision = decide_upstream_manifest(
+            None,
+            false,
+            false,
+            Some(&sample_parent()),
+            "config.yaml",
+            &|_| panic!("should not be called"),
+        );
+        assert_eq!(decision, UpstreamDecision::LocalOnly);
+    }
+
+    #[test]
+    fn no_detected_parent_gives_local_only() {
+        let decision = decide_upstream_manifest(None, false, true, None, "config.yaml", &|_| {
+            panic!("should not be called")
+        });
+        assert_eq!(decision, UpstreamDecision::LocalOnly);
+    }
+
+    #[test]
+    fn user_confirms_gives_use_detected() {
+        let decision = decide_upstream_manifest(
+            None,
+            false,
+            true,
+            Some(&sample_parent()),
+            ".github/gh-sync/config.yaml",
+            &|_| true,
+        );
+        assert_eq!(
+            decision,
+            UpstreamDecision::UseDetected(String::from(
+                "upstream/repo@main:.github/gh-sync/config.yaml"
+            ))
+        );
+    }
+
+    #[test]
+    fn user_declines_gives_local_only() {
+        let decision = decide_upstream_manifest(
+            None,
+            false,
+            true,
+            Some(&sample_parent()),
+            ".github/gh-sync/config.yaml",
+            &|_| false,
+        );
+        assert_eq!(decision, UpstreamDecision::LocalOnly);
+    }
+}

--- a/crates/gh-sync/src/sync/mod.rs
+++ b/crates/gh-sync/src/sync/mod.rs
@@ -1,5 +1,7 @@
 /// CLI argument definitions for the `sync` subcommand
 pub mod cli;
+/// Auto-detection of the fork / template parent repository
+pub mod detect;
 /// Unified diff generation via the `diff` CLI
 pub mod diff;
 /// Error types for manifest validation and sync operations
@@ -25,6 +27,7 @@ use std::io::{self, IsTerminal as _};
 use std::process::ExitCode;
 
 use crate::sync::cli::SyncCommand;
+use crate::sync::runner::SystemGhRunner;
 use crate::sync::strategy::patch::RealPatchRunner;
 use crate::sync::upstream::GhFetcher;
 
@@ -39,6 +42,7 @@ pub fn execute(args: &cli::SyncArgs) -> ExitCode {
 
 /// Execute `sync file` — fetch upstream files, preview, then apply on confirmation.
 #[cfg_attr(coverage_nightly, coverage(off))]
+#[allow(clippy::too_many_lines)]
 fn execute_file(args: &cli::SyncFileArgs) -> ExitCode {
     let mut stdout = io::stdout();
 
@@ -61,21 +65,28 @@ fn execute_file(args: &cli::SyncFileArgs) -> ExitCode {
         };
     }
 
+    // Detect fork/template parent and ask the user if they want to use it as
+    // the upstream manifest, unless --upstream-manifest is already specified.
+    let runner = SystemGhRunner;
+    let effective_upstream = detect::resolve_effective_upstream(
+        args.upstream_manifest.as_deref(),
+        args.yes || args.ci_check || args.dry_run || args.patch_refresh,
+        &args.manifest,
+        &runner,
+    );
+
     // Resolve the effective manifest (upstream fetch + optional local overlay,
     // or just local file when --upstream-manifest is not given).
     let fetcher = GhFetcher;
-    let manifest = match upstream_manifest::resolve(
-        args.upstream_manifest.as_deref(),
-        &args.manifest,
-        &fetcher,
-    ) {
-        Ok(m) => m,
-        Err(e) => {
-            tracing::error!("failed to resolve manifest: {e:#}");
-            tracing::info!("hint: run `gh-sync init` to create a configuration file");
-            return ExitCode::FAILURE;
-        }
-    };
+    let manifest =
+        match upstream_manifest::resolve(effective_upstream.as_deref(), &args.manifest, &fetcher) {
+            Ok(m) => m,
+            Err(e) => {
+                tracing::error!("failed to resolve manifest: {e:#}");
+                tracing::info!("hint: run `gh-sync init` to create a configuration file");
+                return ExitCode::FAILURE;
+            }
+        };
 
     // --validate with --upstream-manifest: validate the merged manifest.
     if args.validate {

--- a/crates/gh-sync/src/sync/repo.rs
+++ b/crates/gh-sync/src/sync/repo.rs
@@ -17,6 +17,7 @@ pub use gh_sync_engine::repo::{
 };
 use gh_sync_manifest::Spec;
 
+use crate::sync::detect;
 use crate::sync::manifest;
 use crate::sync::runner::{GhRunner, SystemGhRunner};
 use crate::sync::upstream::GhFetcher;
@@ -591,29 +592,39 @@ impl<R: GhRunner> GhRepoClient for GhRepoClientImpl<R> {
 #[cfg_attr(coverage_nightly, coverage(off))]
 pub fn execute(args: &super::cli::SyncRepoArgs) -> ExitCode {
     let mut stdout = io::stdout();
-    execute_inner(args, &GhRepoClientImpl::new(), &mut stdout)
+    let runner = SystemGhRunner;
+    let effective_upstream = detect::resolve_effective_upstream(
+        args.upstream_manifest.as_deref(),
+        args.yes || args.ci_check || args.dry_run,
+        &args.manifest,
+        &runner,
+    );
+    execute_inner(
+        args,
+        effective_upstream.as_deref(),
+        &GhRepoClientImpl::new(),
+        &mut stdout,
+    )
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))]
 fn execute_inner(
     args: &super::cli::SyncRepoArgs,
+    effective_upstream_manifest: Option<&str>,
     client: &dyn GhRepoClient,
     w: &mut dyn Write,
 ) -> ExitCode {
     // Resolve the effective manifest (upstream fetch + optional local overlay,
     // or just local file when --upstream-manifest is not given).
     let fetcher = GhFetcher;
-    let manifest = match upstream_manifest::resolve(
-        args.upstream_manifest.as_deref(),
-        &args.manifest,
-        &fetcher,
-    ) {
-        Ok(m) => m,
-        Err(e) => {
-            tracing::error!("failed to resolve manifest: {e:#}");
-            return ExitCode::FAILURE;
-        }
-    };
+    let manifest =
+        match upstream_manifest::resolve(effective_upstream_manifest, &args.manifest, &fetcher) {
+            Ok(m) => m,
+            Err(e) => {
+                tracing::error!("failed to resolve manifest: {e:#}");
+                return ExitCode::FAILURE;
+            }
+        };
 
     // Validate schema before making any API calls.
     // A misconfigured manifest must be caught early to prevent partial apply.
@@ -1894,7 +1905,12 @@ mod tests {
         };
         let client_mock = MockRepoClient::new("owner/repo");
         let mut buf: Vec<u8> = Vec::new();
-        let code = execute_inner(&args, &client_mock, &mut buf);
+        let code = execute_inner(
+            &args,
+            args.upstream_manifest.as_deref(),
+            &client_mock,
+            &mut buf,
+        );
         // Must fail due to validation, before any API calls.
         assert_eq!(code, ExitCode::FAILURE);
         assert!(
@@ -1922,7 +1938,12 @@ mod tests {
         };
         let client_mock = MockRepoClient::new("owner/repo");
         let mut buf: Vec<u8> = Vec::new();
-        let code = execute_inner(&args, &client_mock, &mut buf);
+        let code = execute_inner(
+            &args,
+            args.upstream_manifest.as_deref(),
+            &client_mock,
+            &mut buf,
+        );
         assert_eq!(code, ExitCode::SUCCESS);
         let out = String::from_utf8(buf).unwrap();
         assert!(out.contains("nothing to do"), "unexpected: {out}");
@@ -1947,7 +1968,12 @@ mod tests {
         };
         let client_mock = MockRepoClient::new("owner/repo");
         let mut buf: Vec<u8> = Vec::new();
-        let code = execute_inner(&args, &client_mock, &mut buf);
+        let code = execute_inner(
+            &args,
+            args.upstream_manifest.as_deref(),
+            &client_mock,
+            &mut buf,
+        );
         assert_eq!(code, ExitCode::FAILURE);
     }
 
@@ -1970,7 +1996,12 @@ mod tests {
         };
         let client_mock = MockRepoClient::new("owner/repo");
         let mut buf: Vec<u8> = Vec::new();
-        let code = execute_inner(&args, &client_mock, &mut buf);
+        let code = execute_inner(
+            &args,
+            args.upstream_manifest.as_deref(),
+            &client_mock,
+            &mut buf,
+        );
         assert_eq!(code, ExitCode::SUCCESS);
         assert!(client_mock.applied_patches.borrow().is_empty());
     }

--- a/docs/specs/template-sync.ja.md
+++ b/docs/specs/template-sync.ja.md
@@ -1074,8 +1074,17 @@ naa0yama/boilerplate-rust:.github/gh-sync/config.yaml  # ref 省略 → HEAD
    - 指定された参照を `gh api` で取得し、YAML をパースする
    - `--manifest` に指定されたローカルファイルが存在すれば、`merge_overlay` を適用する
    - ローカルファイルが存在しない場合は upstream マニフェストをそのまま使用する
-2. `--upstream-manifest` が指定されない場合:
-   - 従来どおり `--manifest` のローカルファイルのみを使用する
+2. `--upstream-manifest` が指定されない場合 (自動検出):
+   - TTY 環境かつ `--yes` なし: `gh api repos/{owner}/{repo}` で fork 親または
+     テンプレート親を自動検出し、使用するか確認プロンプトを表示する
+   - ユーザーが承諾した場合: 検出した `owner/repo@branch:manifest-path` を
+     upstream マニフェストとして使用する (上記 1 と同じ流れ)
+   - 非 TTY / `--yes` 指定 / 検出失敗 / ユーザー拒否: ローカルファイルのみを使用する
+
+**自動検出の優先順位**: fork 親 (`parent` フィールド) > テンプレート親 (`template_repository`)
+
+**高速パス**: GitHub Actions 環境では `GITHUB_REPOSITORY` 環境変数を参照し、
+`gh repo view` の呼び出しを省略する。
 
 ### 12.4 マージ規則
 

--- a/docs/specs/template-sync.ja.md
+++ b/docs/specs/template-sync.ja.md
@@ -233,10 +233,10 @@ rules:
 
 #### `patch` 戦略の追加フィールド
 
-| フィールド         | 型      | 必須   | デフォルト                             | 説明                                                                                   |
-| ------------------ | ------- | ------ | -------------------------------------- | -------------------------------------------------------------------------------------- |
-| `patch`            | string  | いいえ | `.github/gh-sync/patches/<path>.patch` | unified diff ファイルのパス(リポジトリルートからの相対)                                |
-| `preserve_markers` | boolean | いいえ | `false`                                | `true` にすると `gh-sync:keep-start` / `gh-sync:keep-end` で囲まれたブロックを保護する |
+| フィールド         | 型      | 必須   | デフォルト                             | 説明                                                                                                              |
+| ------------------ | ------- | ------ | -------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `patch`            | string  | いいえ | `.github/gh-sync/patches/<path>.patch` | unified diff ファイルのパス(リポジトリルートからの相対)                                                           |
+| `preserve_markers` | boolean | いいえ | `false`                                | `true` にすると `gh-sync:keep-start` / `gh-sync:keep-end` で囲まれたブロックを保護する (`patch` / `replace` のみ) |
 
 省略時は `path` をそのまま使い慣例パスを自動解決する。
 慣例から外れる配置にしたい場合のみ明示指定する:
@@ -259,7 +259,8 @@ rules:
 
 - `delete`: `source`, `patch` フィールド不可
 - `patch`: `source` フィールド不可
-- `replace`, `create_only`, `delete`, `ignore`: `patch`, `preserve_markers` フィールド不可
+- `create_only`, `delete`, `ignore`: `patch`, `preserve_markers` フィールド不可
+- `replace`: `patch` フィールド不可 (`preserve_markers` は可)
 - いずれのルールでも未知のフィールドはバリデーションエラー
 
 ### 2.3 パスの制約
@@ -1129,14 +1130,20 @@ files:
 
 ### 12.5.1 preserve_markers — ファイル内マーカーでブロックを保護
 
-`preserve_markers` は `strategy: patch` ルール専用のオプションフィールドで、downstream のファイル内に
-マーカーコメントを書いてブロックを保護する仕組みを有効にする。
+`preserve_markers` は `strategy: patch` または `strategy: replace` ルールに指定できるオプションフィールドで、
+downstream のファイル内にマーカーコメントを書いてブロックを保護する仕組みを有効にする。
 
 ```yaml
-# local overlay (.github/gh-sync/config.yaml)
+# .github/gh-sync/config.yaml
 files:
+  # patch ファイルを使いつつマーカーも保護したい場合
   - path: Cargo.toml
     strategy: patch
+    preserve_markers: true
+
+  # マーカー保護だけが目的で patch ファイル不要の場合
+  - path: .vscode/launch.json
+    strategy: replace
     preserve_markers: true
 ```
 
@@ -1206,7 +1213,7 @@ edition = "2021"
 
 **制約:**
 
-- `strategy: patch` でのみ有効。他の strategy と組み合わせるとスキーマエラーになる。
+- `strategy: patch` または `strategy: replace` でのみ有効。`create_only`、`delete`、`ignore` と組み合わせるとスキーマエラーになる。
 - マーカーのネストは禁止。
 - マーカーのペアが一致しない (orphan) 場合は sync が停止する。
 


### PR DESCRIPTION
## Summary

- `sync/detect.rs` を新規追加し、fork / template 親リポジトリの自動検出ロジックを実装
- `sync file` / `sync repo` で `--upstream-manifest` 未指定かつ TTY 環境の場合、`gh api repos/{owner}/{repo}` で親リポジトリを検出してプロンプト提示
- `init --downstream` / `init --upstream` で `--repo` 未指定時に検出結果をデフォルト値として `dialoguer::Input` に提示
- `--yes`, `--ci-check`, `--dry-run`, `--patch-refresh` 指定時は検出をスキップ (CI 安全性)
- `decide_upstream_manifest` は純粋関数として実装し、単体テストで TTY / dialoguer なしに検証可能
- `feat(engine): allow preserve_markers with strategy replace` も含む

## Test plan

- [ ] `mise run test` で全テストが通ること
- [ ] `mise run pre-commit` (fmt / clippy:strict / ast-grep / lint:gh) が通ること
- [ ] TTY 環境で `sync repo --dry-run` を実行し、template 親の検出プロンプトが表示されること
- [ ] `--yes` 指定時はプロンプトが出ず local-only で動作すること
- [ ] `--upstream-manifest` 指定時はプロンプトが出ないこと
- [ ] `--ci-check` / `--dry-run` 指定時はプロンプトが出ないこと
- [ ] `init --downstream` で `--repo` 未指定時に親リポジトリ名がデフォルト表示されること
- [ ] `init --upstream` で `--repo` 未指定時に現在のリポジトリ名がデフォルト表示されること