### PR TITLE
fix(init): update schema.json when content is stale

### DIFF
--- a/crates/gh-sync/src/init/mod.rs
+++ b/crates/gh-sync/src/init/mod.rs
@@ -305,17 +305,31 @@ fn run_upstream(
     std::fs::write(output, &content)
         .with_context(|| format!("failed to write '{}'", output.display()))?;
 
-    schema::write_schema_file(output_dir)
+    let schema_outcome = schema::write_schema_file(output_dir)
         .with_context(|| format!("failed to write schema.json to '{}'", output_dir.display()))?;
 
     let mut stdout = io::stdout();
     writeln!(stdout, "[OK] created '{}'", output.display()).context("failed to write to stdout")?;
-    writeln!(
-        stdout,
-        "[OK] created '{}/schema.json'",
-        output_dir.display()
-    )
-    .context("failed to write to stdout")?;
+    match schema_outcome {
+        schema::WriteOutcome::Created => writeln!(
+            stdout,
+            "[OK] created '{}/schema.json'",
+            output_dir.display()
+        )
+        .context("failed to write to stdout")?,
+        schema::WriteOutcome::Updated => writeln!(
+            stdout,
+            "[OK] updated '{}/schema.json'",
+            output_dir.display()
+        )
+        .context("failed to write to stdout")?,
+        schema::WriteOutcome::Unchanged => writeln!(
+            stdout,
+            "'{}/schema.json' is already up to date.",
+            output_dir.display()
+        )
+        .context("failed to write to stdout")?,
+    }
 
     Ok(())
 }

--- a/crates/gh-sync/src/init/schema.rs
+++ b/crates/gh-sync/src/init/schema.rs
@@ -1,5 +1,17 @@
-use std::io;
 use std::path::Path;
+
+use anyhow::Context as _;
+
+/// Outcome of a `write_schema_file` call.
+#[derive(Debug, PartialEq, Eq)]
+pub enum WriteOutcome {
+    /// The file did not exist and was created.
+    Created,
+    /// The file existed with different content and was overwritten.
+    Updated,
+    /// The file existed with identical content; no write was performed.
+    Unchanged,
+}
 
 /// JSON Schema for the gh-sync manifest format (yaml-language-server compatible).
 pub const SCHEMA_JSON: &str = r#"{
@@ -339,17 +351,26 @@ pub const fn comment() -> &'static str {
     "# yaml-language-server: $schema=./schema.json\n"
 }
 
-/// Write `schema.json` to `dir` if the file does not already exist.
+/// Write `schema.json` to `dir`, always ensuring the file matches `SCHEMA_JSON`.
 ///
 /// # Errors
 ///
-/// Returns an error when the file cannot be created or written.
-pub fn write_schema_file(dir: &Path) -> io::Result<()> {
+/// Returns an error when the file cannot be read or written.
+pub fn write_schema_file(dir: &Path) -> anyhow::Result<WriteOutcome> {
     let dest = dir.join("schema.json");
-    if dest.exists() {
-        return Ok(());
-    }
-    std::fs::write(dest, SCHEMA_JSON)
+    let outcome = if dest.exists() {
+        let existing = std::fs::read_to_string(&dest)
+            .with_context(|| format!("failed to read '{}'", dest.display()))?;
+        if existing == SCHEMA_JSON {
+            return Ok(WriteOutcome::Unchanged);
+        }
+        WriteOutcome::Updated
+    } else {
+        WriteOutcome::Created
+    };
+    std::fs::write(&dest, SCHEMA_JSON)
+        .with_context(|| format!("failed to write '{}'", dest.display()))?;
+    Ok(outcome)
 }
 
 // ---------------------------------------------------------------------------
@@ -378,17 +399,31 @@ mod tests {
     #[test]
     fn write_schema_file_creates_file() {
         let dir = TempDir::new().unwrap();
-        write_schema_file(dir.path()).unwrap();
+        let outcome = write_schema_file(dir.path()).unwrap();
+        assert_eq!(outcome, WriteOutcome::Created);
         let content = std::fs::read_to_string(dir.path().join("schema.json")).unwrap();
         serde_json::from_str::<serde_json::Value>(&content).unwrap();
     }
 
     #[test]
-    fn write_schema_file_does_not_overwrite() {
+    fn write_schema_file_overwrites_stale_content() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("schema.json");
-        std::fs::write(&path, b"existing").unwrap();
-        write_schema_file(dir.path()).unwrap();
-        assert_eq!(std::fs::read(&path).unwrap(), b"existing");
+        std::fs::write(&path, b"stale").unwrap();
+        let outcome = write_schema_file(dir.path()).unwrap();
+        assert_eq!(outcome, WriteOutcome::Updated);
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(content, SCHEMA_JSON);
+    }
+
+    #[test]
+    fn write_schema_file_returns_unchanged_when_identical() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("schema.json");
+        std::fs::write(&path, SCHEMA_JSON).unwrap();
+        let outcome = write_schema_file(dir.path()).unwrap();
+        assert_eq!(outcome, WriteOutcome::Unchanged);
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(content, SCHEMA_JSON);
     }
 }


### PR DESCRIPTION
## 概要

- `gh-sync init --upstream` を再実行した際、`schema.json` が既に存在すると更新されないバグを修正
- `write_schema_file` が「ファイル存在時は黙ってスキップ」していた挙動を「常に最新の `SCHEMA_JSON` に揃える」挙動に変更
- `WriteOutcome` enum (`Created` / `Updated` / `Unchanged`) を追加し、実行結果に応じたメッセージを出し分けるように修正

## 変更内容

- `crates/gh-sync/src/init/schema.rs`: `WriteOutcome` enum 追加、`write_schema_file` の挙動を修正、テストを差し替え・追加
- `crates/gh-sync/src/init/mod.rs`: `run_upstream` で `WriteOutcome` を `match` して 3 種のメッセージを出力

## テスト計画

- [x] `write_schema_file_creates_file` — 新規作成時に `Created` が返る
- [x] `write_schema_file_overwrites_stale_content` — 古い内容を上書きして `Updated` が返る
- [x] `write_schema_file_returns_unchanged_when_identical` — 内容一致時に `Unchanged` が返り書き込みをスキップ
- [x] `mise run pre-commit` (fmt:check, clippy:strict, ast-grep, lint:gh) 通過済み