### PR TITLE
fix(init): emit explicit version input in generated gh-sync workflow

### DIFF
--- a/.github/workflows/gh-sync.yaml
+++ b/.github/workflows/gh-sync.yaml
@@ -27,6 +27,7 @@ jobs:
       - uses: naa0yama/gh-sync@ede120ca84fcabeb1944e3c301b1f99b3d9185be # v0.3.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          version: v0.3.0
           upstream-manifest: naa0yama/boilerplate-rust@main:.github/gh-sync/config.yaml
           apply-files: "true"
 

--- a/crates/gh-sync/src/init/workflow.rs
+++ b/crates/gh-sync/src/init/workflow.rs
@@ -34,6 +34,7 @@ jobs:
       - uses: naa0yama/gh-sync@{{sha}} # {{version}}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          version: {{version}}
 {{upstream_manifest_line}}
           apply-files: \"true\"
 
@@ -136,6 +137,10 @@ mod tests {
         assert!(
             out.contains("apply-files: \"true\""),
             "missing apply-files input"
+        );
+        assert!(
+            out.contains("version: v0.1.0"),
+            "missing explicit version input"
         );
         assert!(out.contains("gh-sync pr"), "missing gh-sync pr step");
     }


### PR DESCRIPTION
## 概要

- `gh-sync init` が生成するワークフローに `version: {{version}}` 入力を追加
- commit SHA でピンした場合に `github.action_ref` が SHA に解決されるため、`gh release download` が "release not found" で失敗していた
- 既存の `gh-sync.yaml` に `version: v0.3.0` を追記
- `render_contains_required_fields` テストに `version:` 生成の検証を追加

## テスト計画

- [x] `mise run test` 全テスト通過
- [x] `mise run pre-commit` 全チェック通過
- [ ] `workflow_dispatch` で `gh-sync` ワークフローが正常動作することを確認