### PR TITLE
ci: update gh-sync workflow, tagpr, and bump mold

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -24,8 +24,8 @@ changelog:
       labels:
         - manager:mise
         - manager:github-actions
-        - managers:dockerfile
-        - managers:docker-compose
+        - manager:dockerfile
+        - manager:docker-compose
         - manager:regex
         - github-actions
         - renovate-config

--- a/.github/workflows/gh-sync.yaml
+++ b/.github/workflows/gh-sync.yaml
@@ -4,6 +4,8 @@ on:
   schedule:
     - cron: "0 18 * * *" # daily at 03:00 JST
   workflow_dispatch:
+  push:
+    branches: [main]
 
 permissions: {}
 
@@ -13,29 +15,27 @@ concurrency:
 
 jobs:
   gh-sync:
-    name: file-sync
+    name: drift-issue
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: write # Required to create branches and push commits
-      pull-requests: write # Required to create pull requests
+      contents: read
+      issues: write # Required to create and update drift issues
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      - uses: naa0yama/gh-sync@ede120ca84fcabeb1944e3c301b1f99b3d9185be # v0.3.0
+      - uses: naa0yama/gh-sync@1e2635dbfc27e544c28b82ec6faeffd4450154ff # v0.3.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          version: v0.3.0
           upstream-manifest: naa0yama/boilerplate-rust@main:.github/gh-sync/config.yaml
-          apply-files: "true"
+          install-only: "true"
 
-      - name: Create PR if changed
+      - name: Sync drift issue
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh-sync pr \
-            --title "chore: sync files from upstream template" \
-            --body "Automated file sync by gh-sync scheduled workflow." \
-            --branch-prefix "gh-sync/file-sync"
+          gh-sync issue-sync \
+            --manifest .github/gh-sync/config.yaml \
+            --upstream-manifest naa0yama/boilerplate-rust@main:.github/gh-sync/config.yaml

--- a/.github/workflows/tagpr.yaml
+++ b/.github/workflows/tagpr.yaml
@@ -65,21 +65,20 @@ jobs:
           # latestPullRequest() succeeds on its first attempt.
           # Remove this step once Songmu/tagpr extends its retry window.
           # ref: https://github.com/Songmu/tagpr/issues/330
-          MAX_ATTEMPTS=24
-          INTERVAL=5
-          for i in $(seq 1 "${MAX_ATTEMPTS}"); do
+          for i in $(seq 1 24); do
             count=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/pulls" \
               --jq 'length' 2>/dev/null || echo 0)
             if [ "${count}" -gt 0 ]; then
               echo "commit-to-PR index ready after ${i} attempt(s)"
+              # exit 0 ends only this run: shell; the next step still runs.
               exit 0
             fi
-            echo "attempt ${i}/${MAX_ATTEMPTS}: index not ready, sleeping ${INTERVAL}s"
-            sleep "${INTERVAL}"
+            echo "attempt ${i}/24: index not ready, sleeping 5s"
+            sleep 5
           done
           # HEAD may legitimately have no PR (direct push, workflow re-run).
           # Let tagpr's own logic decide rather than failing the job.
-          echo "::warning::commit-to-PR index did not populate within $((MAX_ATTEMPTS * INTERVAL))s; proceeding"
+          echo "::warning::commit-to-PR index did not populate within 120s; proceeding"
 
       - id: tagpr
         uses: Songmu/tagpr@9bbb945b2fb025126186661e27d55485e3fc6df6 # v1.18.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG DEBIAN_FRONTEND=noninteractive \
 	USER_GID=${USER_GID:-${USER_UID}}
 
 ## renovate: datasource=github-releases packageName=rui314/mold versioning=semver automerge=true
-ARG MOLD_VERSION=v2.40.4
+ARG MOLD_VERSION=v2.41.0
 
 # Rust tools
 ## renovate: datasource=github-releases packageName=mozilla/sccache versioning=semver automerge=true


### PR DESCRIPTION
## 概要

- `gh-sync` ワークフローを file-sync PR 方式から issue-sync サブコマンドに移行し、権限を最小化
- `release.yml` のラベル名タイポ (`managers:` → `manager:`) を修正
- `tagpr.yaml` のウェイトループ定数をインライン化
- `mold` を `v2.40.4` → `v2.41.0` にバンプ

## 変更内容

- `ci(gh-sync): migrate from file-sync PR to issue-sync` (#14374b0)
  - `push: branches: [main]` トリガー追加
  - 権限を `pull-requests: write` から `issues: write` に変更
  - `gh-sync` アクションを `v0.3.0` → `v0.3.2` にバンプ
  - `apply-files: true` → `install-only: true` に変更
  - `gh-sync pr` → `gh-sync issue-sync` に移行
- `refactor(tagpr): inline wait loop constants` (#f147494)
  - `MAX_ATTEMPTS=24` / `INTERVAL=5` 変数を削除し、リテラルに直書き
- `build: bump mold to v2.41.0` (#651b494)

## テスト計画

- [ ] CI が全チェックをパスすること
- [ ] gh-sync ワークフローが issue-sync を正常に実行すること