### PR TITLE
fix(sync): prevent HTTP 422 and make all gh errors fully diagnosable

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,3 +247,5 @@ OpenObserve Enterprise Edition は [EULA (End User License Agreement)](https://o
 ```bash
 RUST_LOG=trace RUST_BACKTRACE=1 cargo run -- sync --help
 ```
+
+`RUST_LOG=gh_sync=debug` 以上でログを有効にすると、`GH_DEBUG=api` が `gh` CLI に自動伝搬され、GitHub API の HTTP リクエスト/レスポンスが stderr に出力されます。

--- a/crates/gh-sync-engine/src/repo/apply.rs
+++ b/crates/gh-sync-engine/src/repo/apply.rs
@@ -96,12 +96,28 @@ fn apply_core_fields(
     }
 
     // GitHub API rejects merge-method title/message fields when the method is
-    // disabled. Strip them when the same PATCH disables the method.
-    if patch.get("allow_merge_commit") == Some(&serde_json::json!(false)) {
+    // disabled. Strip them unless the PATCH is explicitly enabling the method
+    // or the spec declares it enabled. Treat None as "do not risk a 422".
+    let merge_enabled = patch.get("allow_merge_commit") == Some(&serde_json::json!(true))
+        || (patch.get("allow_merge_commit").is_none()
+            && spec
+                .merge_strategy
+                .as_ref()
+                .and_then(|m| m.allow_merge_commit)
+                == Some(true));
+    if !merge_enabled {
         patch.remove("merge_commit_title");
         patch.remove("merge_commit_message");
     }
-    if patch.get("allow_squash_merge") == Some(&serde_json::json!(false)) {
+
+    let squash_enabled = patch.get("allow_squash_merge") == Some(&serde_json::json!(true))
+        || (patch.get("allow_squash_merge").is_none()
+            && spec
+                .merge_strategy
+                .as_ref()
+                .and_then(|m| m.allow_squash_merge)
+                == Some(true));
+    if !squash_enabled {
         patch.remove("squash_merge_commit_title");
         patch.remove("squash_merge_commit_message");
     }

--- a/crates/gh-sync-engine/src/repo/tests.rs
+++ b/crates/gh-sync-engine/src/repo/tests.rs
@@ -3589,3 +3589,120 @@ fn apply_core_fields_keeps_merge_commit_fields_when_enabled() {
     assert_eq!(patches[0]["merge_commit_title"], "PR_TITLE");
     assert_eq!(patches[0]["merge_commit_message"], "PR_TITLE");
 }
+
+#[test]
+fn apply_core_fields_strips_merge_commit_fields_when_spec_already_disabled() {
+    // spec says allow_merge_commit=false (live side already disabled),
+    // only title is changing — must NOT reach the PATCH body.
+    let spec = Spec {
+        merge_strategy: Some(MergeStrategy {
+            allow_merge_commit: Some(false),
+            allow_squash_merge: None,
+            allow_rebase_merge: None,
+            allow_auto_merge: None,
+            allow_update_branch: None,
+            auto_delete_head_branches: None,
+            merge_commit_title: Some(String::from("PR_TITLE")),
+            merge_commit_message: Some(String::from("BLANK")),
+            squash_merge_commit_title: None,
+            squash_merge_commit_message: None,
+        }),
+        ..make_spec()
+    };
+    let client = MockRepoClient::new("owner/repo");
+    let changes = vec![
+        SpecChange::FieldChanged {
+            field: String::from("merge_strategy.merge_commit_title"),
+            old: String::from("MERGE_MESSAGE"),
+            new: String::from("PR_TITLE"),
+        },
+        SpecChange::FieldChanged {
+            field: String::from("merge_strategy.merge_commit_message"),
+            old: String::from("PR_TITLE"),
+            new: String::from("BLANK"),
+        },
+    ];
+    apply_changes(&changes, &spec, "owner/repo", &client).unwrap();
+    let patches = client.applied_patches.borrow();
+    // No PATCH should be sent because all changed fields were stripped.
+    assert_eq!(patches.len(), 0);
+}
+
+#[test]
+fn apply_core_fields_strips_squash_fields_when_spec_already_disabled() {
+    let spec = Spec {
+        merge_strategy: Some(MergeStrategy {
+            allow_merge_commit: None,
+            allow_squash_merge: Some(false),
+            allow_rebase_merge: None,
+            allow_auto_merge: None,
+            allow_update_branch: None,
+            auto_delete_head_branches: None,
+            merge_commit_title: None,
+            merge_commit_message: None,
+            squash_merge_commit_title: Some(String::from("PR_TITLE")),
+            squash_merge_commit_message: Some(String::from("BLANK")),
+        }),
+        ..make_spec()
+    };
+    let client = MockRepoClient::new("owner/repo");
+    let changes = vec![
+        SpecChange::FieldChanged {
+            field: String::from("merge_strategy.squash_merge_commit_title"),
+            old: String::from("COMMIT_OR_PR_TITLE"),
+            new: String::from("PR_TITLE"),
+        },
+        SpecChange::FieldChanged {
+            field: String::from("merge_strategy.squash_merge_commit_message"),
+            old: String::from("COMMIT_MESSAGES"),
+            new: String::from("BLANK"),
+        },
+    ];
+    apply_changes(&changes, &spec, "owner/repo", &client).unwrap();
+    let patches = client.applied_patches.borrow();
+    assert_eq!(patches.len(), 0);
+}
+
+#[test]
+fn apply_core_fields_keeps_merge_commit_fields_when_spec_explicitly_enabled() {
+    let spec = Spec {
+        merge_strategy: Some(MergeStrategy {
+            allow_merge_commit: Some(true),
+            allow_squash_merge: None,
+            allow_rebase_merge: None,
+            allow_auto_merge: None,
+            allow_update_branch: None,
+            auto_delete_head_branches: None,
+            merge_commit_title: Some(String::from("PR_TITLE")),
+            merge_commit_message: None,
+            squash_merge_commit_title: None,
+            squash_merge_commit_message: None,
+        }),
+        ..make_spec()
+    };
+    let client = MockRepoClient::new("owner/repo");
+    let changes = vec![SpecChange::FieldChanged {
+        field: String::from("merge_strategy.merge_commit_title"),
+        old: String::from("MERGE_MESSAGE"),
+        new: String::from("PR_TITLE"),
+    }];
+    apply_changes(&changes, &spec, "owner/repo", &client).unwrap();
+    let patches = client.applied_patches.borrow();
+    assert_eq!(patches.len(), 1);
+    assert_eq!(patches[0]["merge_commit_title"], "PR_TITLE");
+}
+
+#[test]
+fn apply_core_fields_strips_merge_commit_fields_when_spec_is_none() {
+    // When spec has no merge_strategy at all, treat as "not enabled" → strip.
+    let spec = make_spec(); // merge_strategy: None
+    let client = MockRepoClient::new("owner/repo");
+    let changes = vec![SpecChange::FieldChanged {
+        field: String::from("merge_strategy.merge_commit_title"),
+        old: String::from("MERGE_MESSAGE"),
+        new: String::from("PR_TITLE"),
+    }];
+    apply_changes(&changes, &spec, "owner/repo", &client).unwrap();
+    let patches = client.applied_patches.borrow();
+    assert_eq!(patches.len(), 0);
+}

--- a/crates/gh-sync/src/init/mod.rs
+++ b/crates/gh-sync/src/init/mod.rs
@@ -205,7 +205,7 @@ fn confirm_overwrite_with_diff(
 /// Writes files appropriate to the selected mode (upstream or downstream).
 #[cfg_attr(coverage_nightly, coverage(off))]
 pub fn execute(args: &InitArgs) -> ExitCode {
-    match run(args, &GhFetcher, &SystemGhRunner) {
+    match run(args, &GhFetcher::new(), &SystemGhRunner) {
         Ok(()) => ExitCode::SUCCESS,
         Err(e) => {
             tracing::error!("init failed: {e:#}");

--- a/crates/gh-sync/src/issue_sync/mod.rs
+++ b/crates/gh-sync/src/issue_sync/mod.rs
@@ -12,7 +12,7 @@ use gh_sync_engine::output::build_pr_comment;
 
 use crate::sync::manifest;
 use crate::sync::repo::{GhRepoClientImpl, RepoCiCheckReport, ci_check_structured};
-use crate::sync::runner::{GhRunner, SystemGhRunner};
+use crate::sync::runner::{GhRunner, SystemGhRunner, run_checked};
 use crate::sync::strategy::patch::RealPatchRunner;
 use crate::sync::upstream::GhFetcher;
 use crate::sync::upstream_manifest;
@@ -55,7 +55,7 @@ pub fn execute(args: &IssueSyncArgs) -> ExitCode {
 /// irrecoverably, or any `gh` CLI call fails.
 pub fn run(args: &IssueSyncArgs, runner: &dyn GhRunner) -> anyhow::Result<bool> {
     let repo_root = Path::new(".");
-    let fetcher = GhFetcher;
+    let fetcher = GhFetcher::new();
     let patch_runner = RealPatchRunner;
 
     // Resolve the effective manifest.
@@ -204,27 +204,19 @@ fn resolve_repo(arg_repo: Option<&str>, runner: &dyn GhRunner) -> anyhow::Result
         return Ok(env_repo);
     }
 
-    let out = runner
-        .run(
-            &[
-                "repo",
-                "view",
-                "--json",
-                "nameWithOwner",
-                "--jq",
-                ".nameWithOwner",
-            ],
-            None,
-        )
-        .context("failed to spawn `gh`")?;
-
-    if !out.success() {
-        let stderr = String::from_utf8_lossy(&out.stderr);
-        anyhow::bail!(
-            "failed to detect repository via `gh repo view`: {stderr}\n\
-             Use --repo owner/repo to specify it explicitly."
-        );
-    }
+    let out = run_checked(
+        runner,
+        &[
+            "repo",
+            "view",
+            "--json",
+            "nameWithOwner",
+            "--jq",
+            ".nameWithOwner",
+        ],
+        None,
+        "gh repo view",
+    )?;
 
     Ok(String::from_utf8_lossy(&out.stdout).trim().to_owned())
 }
@@ -237,20 +229,15 @@ fn resolve_repo(arg_repo: Option<&str>, runner: &dyn GhRunner) -> anyhow::Result
 ///
 /// Returns `None` when no matching open issue exists.
 fn find_open_issue(repo: &str, label: &str, runner: &dyn GhRunner) -> anyhow::Result<Option<u64>> {
-    let out = runner
-        .run(
-            &[
-                "issue", "list", "--repo", repo, "--label", label, "--state", "open", "--json",
-                "number", "--limit", "10",
-            ],
-            None,
-        )
-        .context("failed to spawn `gh`")?;
-
-    if !out.success() {
-        let stderr = String::from_utf8_lossy(&out.stderr);
-        anyhow::bail!("gh issue list failed: {stderr}");
-    }
+    let out = run_checked(
+        runner,
+        &[
+            "issue", "list", "--repo", repo, "--label", label, "--state", "open", "--json",
+            "number", "--limit", "10",
+        ],
+        None,
+        &format!("gh issue list --repo {repo}"),
+    )?;
 
     let json: serde_json::Value =
         serde_json::from_slice(&out.stdout).context("failed to parse gh issue list JSON")?;
@@ -265,50 +252,40 @@ fn find_open_issue(repo: &str, label: &str, runner: &dyn GhRunner) -> anyhow::Re
 
 /// Edit the body of an existing issue.
 fn edit_issue(runner: &dyn GhRunner, repo: &str, number: u64, body: &str) -> anyhow::Result<()> {
-    let out = runner
-        .run(
-            &[
-                "issue",
-                "edit",
-                &number.to_string(),
-                "--repo",
-                repo,
-                "--body-file",
-                "-",
-            ],
-            Some(body.as_bytes()),
-        )
-        .context("failed to spawn `gh`")?;
-
-    if !out.success() {
-        let stderr = String::from_utf8_lossy(&out.stderr);
-        anyhow::bail!("gh issue edit failed: {stderr}");
-    }
+    run_checked(
+        runner,
+        &[
+            "issue",
+            "edit",
+            &number.to_string(),
+            "--repo",
+            repo,
+            "--body-file",
+            "-",
+        ],
+        Some(body.as_bytes()),
+        &format!("gh issue edit #{number} --repo {repo}"),
+    )?;
     Ok(())
 }
 
 /// Ensure a label exists in `repo` (idempotent via `--force`).
 fn ensure_label(runner: &dyn GhRunner, repo: &str, label: &str) -> anyhow::Result<()> {
-    let out = runner
-        .run(
-            &[
-                "label",
-                "create",
-                label,
-                "--repo",
-                repo,
-                "--force",
-                "--description",
-                "Upstream drift detected by gh-sync",
-            ],
-            None,
-        )
-        .context("failed to spawn `gh`")?;
-
-    if !out.success() {
-        let stderr = String::from_utf8_lossy(&out.stderr);
-        anyhow::bail!("gh label create failed: {stderr}");
-    }
+    run_checked(
+        runner,
+        &[
+            "label",
+            "create",
+            label,
+            "--repo",
+            repo,
+            "--force",
+            "--description",
+            "Upstream drift detected by gh-sync",
+        ],
+        None,
+        &format!("gh label create {label} --repo {repo}"),
+    )?;
     Ok(())
 }
 
@@ -320,28 +297,23 @@ fn create_issue(
     title: &str,
     body: &str,
 ) -> anyhow::Result<()> {
-    let out = runner
-        .run(
-            &[
-                "issue",
-                "create",
-                "--repo",
-                repo,
-                "--label",
-                label,
-                "--title",
-                title,
-                "--body-file",
-                "-",
-            ],
-            Some(body.as_bytes()),
-        )
-        .context("failed to spawn `gh`")?;
-
-    if !out.success() {
-        let stderr = String::from_utf8_lossy(&out.stderr);
-        anyhow::bail!("gh issue create failed: {stderr}");
-    }
+    let out = run_checked(
+        runner,
+        &[
+            "issue",
+            "create",
+            "--repo",
+            repo,
+            "--label",
+            label,
+            "--title",
+            title,
+            "--body-file",
+            "-",
+        ],
+        Some(body.as_bytes()),
+        &format!("gh issue create --repo {repo}"),
+    )?;
 
     let url = String::from_utf8_lossy(&out.stdout).trim().to_owned();
     let mut stdout = io::stdout();
@@ -354,38 +326,28 @@ fn close_issue(runner: &dyn GhRunner, repo: &str, number: u64) -> anyhow::Result
     // Comment first.
     let sha = std::env::var("GITHUB_SHA").unwrap_or_else(|_| String::from("(unknown)"));
     let comment_body = format!("Drift resolved at {sha}.");
-    let out = runner
-        .run(
-            &[
-                "issue",
-                "comment",
-                &number.to_string(),
-                "--repo",
-                repo,
-                "--body",
-                &comment_body,
-            ],
-            None,
-        )
-        .context("failed to spawn `gh`")?;
-
-    if !out.success() {
-        let stderr = String::from_utf8_lossy(&out.stderr);
-        anyhow::bail!("gh issue comment failed: {stderr}");
-    }
+    run_checked(
+        runner,
+        &[
+            "issue",
+            "comment",
+            &number.to_string(),
+            "--repo",
+            repo,
+            "--body",
+            &comment_body,
+        ],
+        None,
+        &format!("gh issue comment #{number} --repo {repo}"),
+    )?;
 
     // Then close.
-    let out = runner
-        .run(
-            &["issue", "close", &number.to_string(), "--repo", repo],
-            None,
-        )
-        .context("failed to spawn `gh`")?;
-
-    if !out.success() {
-        let stderr = String::from_utf8_lossy(&out.stderr);
-        anyhow::bail!("gh issue close failed: {stderr}");
-    }
+    run_checked(
+        runner,
+        &["issue", "close", &number.to_string(), "--repo", repo],
+        None,
+        &format!("gh issue close #{number} --repo {repo}"),
+    )?;
 
     let mut stdout = io::stdout();
     let _ = writeln!(stdout, "[OK] drift issue #{number} closed");

--- a/crates/gh-sync/src/main.rs
+++ b/crates/gh-sync/src/main.rs
@@ -21,6 +21,7 @@ fn main() -> ExitCode {
         .with_env_filter(
             EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn")),
         )
+        .with_writer(std::io::stderr)
         .init();
 
     let cli = Cli::parse();

--- a/crates/gh-sync/src/sync/detect.rs
+++ b/crates/gh-sync/src/sync/detect.rs
@@ -7,7 +7,7 @@
 
 use anyhow::Context as _;
 
-use crate::sync::runner::GhRunner;
+use crate::sync::runner::{GhRunner, run_checked};
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -88,26 +88,19 @@ pub fn detect_current_repo(runner: &dyn GhRunner) -> anyhow::Result<String> {
         return Ok(v);
     }
 
-    let out = runner
-        .run(
-            &[
-                "repo",
-                "view",
-                "--json",
-                "nameWithOwner",
-                "--jq",
-                ".nameWithOwner",
-            ],
-            None,
-        )
-        .context("failed to spawn `gh repo view`")?;
-
-    if !out.success() {
-        anyhow::bail!(
-            "`gh repo view` failed: {}",
-            String::from_utf8_lossy(&out.stderr)
-        );
-    }
+    let out = run_checked(
+        runner,
+        &[
+            "repo",
+            "view",
+            "--json",
+            "nameWithOwner",
+            "--jq",
+            ".nameWithOwner",
+        ],
+        None,
+        "gh repo view",
+    )?;
 
     Ok(String::from_utf8_lossy(&out.stdout).trim().to_owned())
 }
@@ -127,14 +120,7 @@ pub fn detect_upstream_parent(
     current_repo: &str,
 ) -> anyhow::Result<Option<UpstreamParent>> {
     let url = format!("repos/{current_repo}");
-    let out = runner
-        .run(&["api", &url], None)
-        .context("failed to spawn `gh api`")?;
-
-    if !out.success() {
-        let stderr = String::from_utf8_lossy(&out.stderr);
-        anyhow::bail!("`gh api {url}` failed: {stderr}");
-    }
+    let out = run_checked(runner, &["api", &url], None, &format!("GET {url}"))?;
 
     let meta: RepoMeta =
         serde_json::from_slice(&out.stdout).context("failed to parse repository metadata JSON")?;

--- a/crates/gh-sync/src/sync/gh_error.rs
+++ b/crates/gh-sync/src/sync/gh_error.rs
@@ -1,0 +1,343 @@
+use std::borrow::Cow;
+
+use serde::Deserialize;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// A single field-level GitHub API error.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct GhApiFieldError {
+    pub resource: Option<String>,
+    pub field: Option<String>,
+    pub code: Option<String>,
+    pub message: Option<String>,
+}
+
+/// Parsed GitHub API error response.
+#[derive(Debug, Clone, Default)]
+pub struct GhApiError {
+    pub status: Option<u16>,
+    pub message: Option<String>,
+    pub errors: Vec<GhApiFieldError>,
+    #[allow(dead_code)] // included for completeness; not shown in bail messages
+    pub documentation_url: Option<String>,
+    pub request_id: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Raw deserialization helper
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct RawApiError {
+    message: Option<String>,
+    status: Option<serde_json::Value>,
+    errors: Option<serde_json::Value>,
+    documentation_url: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Public functions
+// ---------------------------------------------------------------------------
+
+/// Parse API error from gh stdout/stderr streams.
+///
+/// stdout is tried first (gh api writes JSON error there on 4xx).
+/// Falls back to stderr for plain text gh messages.
+pub fn parse_from_streams(stdout: &[u8], stderr: &[u8]) -> Option<GhApiError> {
+    // Try stdout JSON first.
+    let stdout_result = std::str::from_utf8(stdout)
+        .ok()
+        .filter(|s| s.contains('{'))
+        .and_then(extract_json)
+        .and_then(parse_json_error);
+
+    if stdout_result.is_some() {
+        return stdout_result;
+    }
+
+    // Falls back to stderr JSON, then plain gh message format.
+    let stderr_str = std::str::from_utf8(stderr).ok()?;
+
+    let stderr_json = stderr_str
+        .contains('{')
+        .then(|| extract_json(stderr_str))
+        .flatten()
+        .and_then(parse_json_error);
+
+    stderr_json.or_else(|| try_parse_gh_message(stderr_str))
+}
+
+/// Truncate `s` to the last `max` bytes (character boundary).
+///
+/// Prepends `"...(truncated {orig} -> {max} bytes)\n"` when truncated.
+pub fn truncate_tail(s: &str, max: usize) -> Cow<'_, str> {
+    if s.len() <= max {
+        return Cow::Borrowed(s);
+    }
+
+    // Find a valid UTF-8 boundary at or after `s.len() - max`.
+    // saturating_sub is safe because s.len() > max (guard above).
+    let start_raw = s.len().saturating_sub(max);
+    let start = (start_raw..=s.len())
+        .find(|&i| s.is_char_boundary(i))
+        .unwrap_or(s.len());
+
+    let tail = &s[start..];
+    let header = format!("...(truncated {} -> {} bytes)\n", s.len(), max);
+    Cow::Owned(format!("{header}{tail}"))
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+// Extract the leading balanced {...} JSON object from s.
+// Returns None if no valid JSON object found.
+fn extract_json(s: &str) -> Option<&str> {
+    let start = s.find('{')?;
+    let bytes = s.as_bytes();
+    let mut depth: u32 = 0;
+    let mut in_string = false;
+    let mut escaped = false;
+
+    for (i, &ch) in bytes.iter().enumerate().skip(start) {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        if ch == b'\\' && in_string {
+            escaped = true;
+            continue;
+        }
+        if ch == b'"' {
+            in_string = !in_string;
+            continue;
+        }
+        if in_string {
+            continue;
+        }
+        match ch {
+            b'{' => depth = depth.saturating_add(1),
+            b'}' => {
+                depth = depth.saturating_sub(1);
+                if depth == 0 {
+                    return s.get(start..=i);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    None
+}
+
+// Infer HTTP status from status_json field (may be number or string like "422")
+// and from common substrings in message (e.g. "HTTP 404", "Not Found", "Forbidden").
+fn infer_http_status(status_val: Option<&serde_json::Value>, message: &str) -> Option<u16> {
+    if let Some(val) = status_val {
+        match val {
+            serde_json::Value::Number(n) => {
+                if let Some(u) = n.as_u64() {
+                    return u16::try_from(u).ok();
+                }
+            }
+            serde_json::Value::String(s) => {
+                if let Ok(n) = s.parse::<u16>() {
+                    return Some(n);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // Fall back to message-based inference.
+    if message.contains("HTTP 404") {
+        Some(404)
+    } else if message.contains("HTTP 401") {
+        Some(401)
+    } else if message.contains("HTTP 403") {
+        Some(403)
+    } else if message.contains("HTTP 422") {
+        Some(422)
+    } else if message.contains("Not Found") {
+        Some(404)
+    } else if message.contains("Unauthorized") {
+        Some(401)
+    } else if message.contains("Forbidden") {
+        Some(403)
+    } else if message.contains("Validation Failed") {
+        Some(422)
+    } else {
+        None
+    }
+}
+
+// Parse the gh CLI human-readable format: "gh: <detail> (Status Label)"
+// e.g. "gh: Validation Failed (HTTP 422)"
+fn try_parse_gh_message(stderr: &str) -> Option<GhApiError> {
+    // rfind is used so nested parens like "(detail) (HTTP 422)" correctly pick
+    // up the outermost label at the end of the line.
+    let last_open = stderr.rfind('(')?;
+    let last_close = stderr.rfind(')')?;
+    if last_close <= last_open {
+        return None;
+    }
+
+    let label = stderr.get(last_open.saturating_add(1)..last_close)?;
+
+    // Extract detail between "gh: " and the label parenthesis.
+    let detail = stderr
+        .find("gh: ")
+        .map_or(stderr, |idx| &stderr[idx.saturating_add(4)..]);
+    let detail = detail
+        .rfind('(')
+        .map_or(detail, |idx| detail[..idx].trim_end());
+
+    let status = infer_http_status(None, label)?;
+
+    Some(GhApiError {
+        status: Some(status),
+        message: Some(label.to_owned()),
+        errors: if detail.is_empty() || detail == label {
+            vec![]
+        } else {
+            vec![GhApiFieldError {
+                message: Some(detail.to_owned()),
+                ..Default::default()
+            }]
+        },
+        documentation_url: None,
+        request_id: None,
+    })
+}
+
+// Parse a JSON string slice into a GhApiError. Returns None if the message is empty.
+fn parse_json_error(json_str: &str) -> Option<GhApiError> {
+    let Ok(raw) = serde_json::from_str::<RawApiError>(json_str) else {
+        return None;
+    };
+    let message = raw.message.filter(|m| !m.is_empty())?;
+
+    let field_errors = match raw.errors {
+        Some(serde_json::Value::Array(arr)) => {
+            let as_objects: Result<Vec<GhApiFieldError>, _> =
+                serde_json::from_value(serde_json::Value::Array(arr.clone()));
+            as_objects.unwrap_or_else(|_| {
+                let as_strings: Result<Vec<String>, _> =
+                    serde_json::from_value(serde_json::Value::Array(arr));
+                as_strings
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|s| GhApiFieldError {
+                        message: Some(s),
+                        ..Default::default()
+                    })
+                    .collect()
+            })
+        }
+        _ => vec![],
+    };
+
+    let status = infer_http_status(raw.status.as_ref(), &message);
+
+    Some(GhApiError {
+        status,
+        message: Some(message),
+        errors: field_errors,
+        documentation_url: raw.documentation_url,
+        request_id: None,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::indexing_slicing)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_from_streams_prefers_stdout_json() {
+        let stdout = br#"{"message":"stdout error","status":"404"}"#;
+        let stderr = b"gh: some other error (HTTP 422)";
+        let result = parse_from_streams(stdout, stderr).unwrap();
+        assert_eq!(result.message.as_deref(), Some("stdout error"));
+    }
+
+    #[test]
+    fn parse_from_streams_extracts_field_level_errors() {
+        let stdout = br#"{"message":"Validation Failed","errors":[{"resource":"Repository","field":"merge_commit_title","code":"invalid"}],"documentation_url":"https://docs.github.com","status":"422"}"#;
+        let result = parse_from_streams(stdout, b"").unwrap();
+        assert_eq!(
+            result.errors[0].field.as_deref(),
+            Some("merge_commit_title")
+        );
+    }
+
+    #[test]
+    fn parse_from_streams_falls_back_to_stderr() {
+        let stdout = b"";
+        let stderr = br#"{"message":"stderr error","status":"403"}"#;
+        let result = parse_from_streams(stdout, stderr).unwrap();
+        assert_eq!(result.message.as_deref(), Some("stderr error"));
+    }
+
+    #[test]
+    fn parse_from_streams_infers_status_from_gh_prefix_text() {
+        let stdout = b"";
+        let stderr = b"gh: Validation Failed (HTTP 422)";
+        let result = parse_from_streams(stdout, stderr).unwrap();
+        assert_eq!(result.status, Some(422));
+    }
+
+    #[test]
+    fn parse_from_streams_handles_string_errors_array() {
+        let stdout = br#"{"message":"Something went wrong","errors":["some error string"]}"#;
+        let result = parse_from_streams(stdout, b"").unwrap();
+        assert_eq!(
+            result.errors[0].message.as_deref(),
+            Some("some error string")
+        );
+    }
+
+    #[test]
+    fn truncate_tail_short_string_unchanged() {
+        let s = "hello";
+        let result = truncate_tail(s, 10);
+        assert!(matches!(result, Cow::Borrowed(_)));
+        assert_eq!(result.as_ref(), "hello");
+    }
+
+    #[test]
+    fn truncate_tail_long_string_truncated() {
+        let s = "abcdefghijklmnopqrstuvwxyz";
+        let result = truncate_tail(s, 10);
+        assert!(matches!(result, Cow::Owned(_)));
+        let r = result.as_ref();
+        assert!(r.contains("truncated"));
+        assert!(r.ends_with("qrstuvwxyz"));
+    }
+
+    #[test]
+    fn infer_status_from_http_prefix() {
+        assert_eq!(infer_http_status(None, "something (HTTP 404)"), Some(404));
+    }
+
+    #[test]
+    fn infer_status_from_branch_not_protected() {
+        assert_eq!(
+            infer_http_status(None, "Branch not protected: Not Found"),
+            Some(404)
+        );
+    }
+
+    #[test]
+    fn infer_status_from_422_validation() {
+        assert_eq!(infer_http_status(None, "Validation Failed"), Some(422));
+    }
+}

--- a/crates/gh-sync/src/sync/mod.rs
+++ b/crates/gh-sync/src/sync/mod.rs
@@ -6,6 +6,8 @@ pub mod detect;
 pub mod diff;
 /// Error types for manifest validation and sync operations
 pub mod error;
+/// Parsing GitHub API error responses from gh CLI stdout/stderr
+pub mod gh_error;
 /// Manifest schema, loading, and validation
 pub mod manifest;
 /// Synchronisation modes (validate, sync, ci-check, patch-refresh)
@@ -77,7 +79,7 @@ fn execute_file(args: &cli::SyncFileArgs) -> ExitCode {
 
     // Resolve the effective manifest (upstream fetch + optional local overlay,
     // or just local file when --upstream-manifest is not given).
-    let fetcher = GhFetcher;
+    let fetcher = GhFetcher::new();
     let manifest =
         match upstream_manifest::resolve(effective_upstream.as_deref(), &args.manifest, &fetcher) {
             Ok(m) => m,

--- a/crates/gh-sync/src/sync/repo.rs
+++ b/crates/gh-sync/src/sync/repo.rs
@@ -18,8 +18,9 @@ pub use gh_sync_engine::repo::{
 use gh_sync_manifest::Spec;
 
 use crate::sync::detect;
+use crate::sync::gh_error;
 use crate::sync::manifest;
-use crate::sync::runner::{GhRunner, SystemGhRunner};
+use crate::sync::runner::{GhRunner, SystemGhRunner, run_checked};
 use crate::sync::upstream::GhFetcher;
 use crate::sync::upstream_manifest;
 
@@ -59,16 +60,7 @@ impl Default for GhRepoClientImpl<SystemGhRunner> {
 impl<R: GhRunner> GhRepoClientImpl<R> {
     /// `gh api <url>` → raw bytes.
     fn gh_api_get(&self, url: &str) -> anyhow::Result<Vec<u8>> {
-        let out = self
-            .runner
-            .run(&["api", url], None)
-            .with_context(|| format!("failed to spawn `gh api {url}`"))?;
-        if !out.success() {
-            anyhow::bail!(
-                "`gh api GET {url}` failed: {}",
-                String::from_utf8_lossy(&out.stderr)
-            );
-        }
+        let out = run_checked(&self.runner, &["api", url], None, &format!("GET {url}"))?;
         Ok(out.stdout)
     }
 
@@ -87,19 +79,12 @@ impl<R: GhRunner> GhRepoClientImpl<R> {
         body: &serde_json::Value,
     ) -> anyhow::Result<()> {
         let json = serde_json::to_string(body).context("failed to serialize body")?;
-        let out = self
-            .runner
-            .run(
-                &["api", "-X", method, url, "--input", "-"],
-                Some(json.as_bytes()),
-            )
-            .with_context(|| format!("failed to spawn `gh api {method} {url}`"))?;
-        if !out.success() {
-            anyhow::bail!(
-                "`gh api {method} {url}` failed: {}",
-                String::from_utf8_lossy(&out.stderr)
-            );
-        }
+        run_checked(
+            &self.runner,
+            &["api", "-X", method, url, "--input", "-"],
+            Some(json.as_bytes()),
+            &format!("{method} {url}"),
+        )?;
         Ok(())
     }
 }
@@ -110,26 +95,19 @@ impl<R: GhRunner> GhRepoClientImpl<R> {
 
 impl<R: GhRunner> GhRepoClient for GhRepoClientImpl<R> {
     fn detect_repo(&self) -> anyhow::Result<String> {
-        let out = self
-            .runner
-            .run(
-                &[
-                    "repo",
-                    "view",
-                    "--json",
-                    "nameWithOwner",
-                    "-q",
-                    ".nameWithOwner",
-                ],
-                None,
-            )
-            .context("failed to spawn `gh repo view`")?;
-        if !out.success() {
-            anyhow::bail!(
-                "`gh repo view` failed: {}",
-                String::from_utf8_lossy(&out.stderr)
-            );
-        }
+        let out = run_checked(
+            &self.runner,
+            &[
+                "repo",
+                "view",
+                "--json",
+                "nameWithOwner",
+                "-q",
+                ".nameWithOwner",
+            ],
+            None,
+            "gh repo view",
+        )?;
         Ok(String::from_utf8_lossy(&out.stdout).trim().to_owned())
     }
 
@@ -151,28 +129,21 @@ impl<R: GhRunner> GhRepoClient for GhRepoClientImpl<R> {
     }
 
     fn fetch_labels(&self, repo: &str) -> anyhow::Result<Vec<ApiLabel>> {
-        let out = self
-            .runner
-            .run(
-                &[
-                    "label",
-                    "list",
-                    "--repo",
-                    repo,
-                    "--limit",
-                    "1000",
-                    "--json",
-                    "name,color,description",
-                ],
-                None,
-            )
-            .with_context(|| format!("failed to spawn `gh label list --repo {repo}`"))?;
-        if !out.success() {
-            anyhow::bail!(
-                "`gh label list` failed: {}",
-                String::from_utf8_lossy(&out.stderr)
-            );
-        }
+        let out = run_checked(
+            &self.runner,
+            &[
+                "label",
+                "list",
+                "--repo",
+                repo,
+                "--limit",
+                "1000",
+                "--json",
+                "name,color,description",
+            ],
+            None,
+            &format!("gh label list --repo {repo}"),
+        )?;
         let items: Vec<serde_json::Value> =
             serde_json::from_slice(&out.stdout).context("failed to parse labels JSON")?;
         Ok(items
@@ -262,33 +233,34 @@ impl<R: GhRunner> GhRepoClient for GhRepoClientImpl<R> {
         repo: &str,
         branch: &str,
     ) -> anyhow::Result<Option<BranchProtectionApi>> {
-        let out = self
-            .runner
-            .run(
-                &["api", &format!("repos/{repo}/branches/{branch}/protection")],
-                None,
-            )
-            .with_context(|| {
-                format!("failed to spawn `gh api` for branch protection {repo}/{branch}")
-            })?;
-        if out.exit_code == Some(1) {
-            let body = String::from_utf8_lossy(&out.stderr);
-            if body.contains("404") || body.contains(BRANCH_NOT_PROTECTED) {
+        let op = format!("GET repos/{repo}/branches/{branch}/protection");
+        let out = self.runner.run(
+            &["api", &format!("repos/{repo}/branches/{branch}/protection")],
+            None,
+        )?;
+        if !out.success() {
+            let api_err = gh_error::parse_from_streams(&out.stdout, &out.stderr);
+            let status = api_err.as_ref().and_then(|e| e.status);
+            let stderr_str = String::from_utf8_lossy(&out.stderr);
+            // 2-stage: API status first, string fallback.
+            if status == Some(404)
+                || (status.is_none()
+                    && (stderr_str.contains("404") || stderr_str.contains(BRANCH_NOT_PROTECTED)))
+            {
                 return Ok(None);
             }
-        }
-        if !out.success() {
+            // Check stdout JSON for BRANCH_NOT_PROTECTED (existing logic).
             if let Ok(v) = serde_json::from_slice::<serde_json::Value>(&out.stdout)
                 && v.get("message").and_then(serde_json::Value::as_str)
                     == Some(BRANCH_NOT_PROTECTED)
             {
                 return Ok(None);
             }
-            anyhow::bail!(
-                "`gh api` branch protection failed: {}{}",
-                String::from_utf8_lossy(&out.stdout),
-                String::from_utf8_lossy(&out.stderr)
-            );
+            let exit_code = out.exit_code;
+            let stdout_str = String::from_utf8_lossy(&out.stdout);
+            tracing::error!(%op, ?exit_code, stderr = %stderr_str, stdout = %stdout_str, ?api_err, "gh command failed");
+            let stderr_summary = gh_error::truncate_tail(&stderr_str, 2048);
+            anyhow::bail!("{op} failed (exit {exit_code:?}): {stderr_summary}");
         }
         let v: serde_json::Value =
             serde_json::from_slice(&out.stdout).context("failed to parse branch protection")?;
@@ -313,17 +285,25 @@ impl<R: GhRunner> GhRepoClient for GhRepoClientImpl<R> {
     }
 
     fn fetch_release_immutability(&self, repo: &str) -> anyhow::Result<Option<bool>> {
+        let op = format!("GET repos/{repo}/immutable-releases");
         let out = self
             .runner
-            .run(&["api", &format!("repos/{repo}/immutable-releases")], None)
-            .with_context(|| format!("failed to spawn `gh api` for immutable-releases {repo}"))?;
+            .run(&["api", &format!("repos/{repo}/immutable-releases")], None)?;
         if !out.success() {
-            let stderr = String::from_utf8_lossy(&out.stderr);
-            // 404/403 means the endpoint is not available (e.g. GHES without support).
-            if stderr.contains("404") || stderr.contains("403") {
+            let api_err = gh_error::parse_from_streams(&out.stdout, &out.stderr);
+            let status = api_err.as_ref().and_then(|e| e.status);
+            let stderr_str = String::from_utf8_lossy(&out.stderr);
+            // 2-stage: 404/403 means endpoint not available (e.g. GHES without support).
+            if matches!(status, Some(404 | 403))
+                || (status.is_none() && (stderr_str.contains("404") || stderr_str.contains("403")))
+            {
                 return Ok(None);
             }
-            anyhow::bail!("`gh api GET immutable-releases` failed: {stderr}");
+            let exit_code = out.exit_code;
+            let stdout_str = String::from_utf8_lossy(&out.stdout);
+            tracing::error!(%op, ?exit_code, stderr = %stderr_str, stdout = %stdout_str, ?api_err, "gh command failed");
+            let stderr_summary = gh_error::truncate_tail(&stderr_str, 2048);
+            anyhow::bail!("{op} failed (exit {exit_code:?}): {stderr_summary}");
         }
         let v: serde_json::Value = serde_json::from_slice(&out.stdout)
             .context("failed to parse immutable-releases JSON")?;
@@ -332,47 +312,44 @@ impl<R: GhRunner> GhRepoClient for GhRepoClientImpl<R> {
 
     fn put_release_immutability(&self, repo: &str, enabled: bool) -> anyhow::Result<()> {
         let method = if enabled { "PUT" } else { "DELETE" };
-        let out = self
-            .runner
-            .run(
-                &[
-                    "api",
-                    "-X",
-                    method,
-                    &format!("repos/{repo}/immutable-releases"),
-                ],
-                None,
-            )
-            .with_context(|| {
-                format!("failed to spawn `gh api {method} immutable-releases {repo}`")
-            })?;
-        if !out.success() {
-            anyhow::bail!(
-                "`gh api {method} immutable-releases` failed: {}",
-                String::from_utf8_lossy(&out.stderr)
-            );
-        }
+        run_checked(
+            &self.runner,
+            &[
+                "api",
+                "-X",
+                method,
+                &format!("repos/{repo}/immutable-releases"),
+            ],
+            None,
+            &format!("{method} repos/{repo}/immutable-releases"),
+        )?;
         Ok(())
     }
 
     fn fetch_fork_pr_approval(&self, repo: &str) -> anyhow::Result<Option<String>> {
-        let out = self
-            .runner
-            .run(
-                &[
-                    "api",
-                    &format!("repos/{repo}/actions/permissions/fork-pr-contributor-approval"),
-                ],
-                None,
-            )
-            .with_context(|| format!("failed to spawn `gh api` for fork-pr-approval {repo}"))?;
+        let op = format!("GET repos/{repo}/actions/permissions/fork-pr-contributor-approval");
+        let out = self.runner.run(
+            &[
+                "api",
+                &format!("repos/{repo}/actions/permissions/fork-pr-contributor-approval"),
+            ],
+            None,
+        )?;
         if !out.success() {
-            let stderr = String::from_utf8_lossy(&out.stderr);
-            // 404 = user-owned repo, 422 = private repo — both are expected
-            if stderr.contains("404") || stderr.contains("422") {
+            let api_err = gh_error::parse_from_streams(&out.stdout, &out.stderr);
+            let status = api_err.as_ref().and_then(|e| e.status);
+            let stderr_str = String::from_utf8_lossy(&out.stderr);
+            // 2-stage: 404 = user-owned repo, 422 = private repo — both are expected.
+            if matches!(status, Some(404 | 422))
+                || (status.is_none() && (stderr_str.contains("404") || stderr_str.contains("422")))
+            {
                 return Ok(None);
             }
-            anyhow::bail!("`gh api GET fork-pr-contributor-approval` failed: {stderr}");
+            let exit_code = out.exit_code;
+            let stdout_str = String::from_utf8_lossy(&out.stdout);
+            tracing::error!(%op, ?exit_code, stderr = %stderr_str, stdout = %stdout_str, ?api_err, "gh command failed");
+            let stderr_summary = gh_error::truncate_tail(&stderr_str, 2048);
+            anyhow::bail!("{op} failed (exit {exit_code:?}): {stderr_summary}");
         }
         let v: serde_json::Value = serde_json::from_slice(&out.stdout)
             .context("failed to parse fork-pr-contributor-approval JSON")?;
@@ -410,16 +387,12 @@ impl<R: GhRunner> GhRepoClient for GhRepoClientImpl<R> {
         if let Some(desc) = description {
             args.extend_from_slice(&["--description", desc]);
         }
-        let out = self
-            .runner
-            .run(&args, None)
-            .with_context(|| format!("failed to spawn `gh label create {name} --repo {repo}`"))?;
-        if !out.success() {
-            anyhow::bail!(
-                "`gh label create` failed: {}",
-                String::from_utf8_lossy(&out.stderr)
-            );
-        }
+        run_checked(
+            &self.runner,
+            &args,
+            None,
+            &format!("gh label create {name} --repo {repo}"),
+        )?;
         Ok(())
     }
 
@@ -434,33 +407,22 @@ impl<R: GhRunner> GhRepoClient for GhRepoClientImpl<R> {
         if let Some(desc) = description {
             args.extend_from_slice(&["--description", desc]);
         }
-        let out = self
-            .runner
-            .run(&args, None)
-            .with_context(|| format!("failed to spawn `gh label edit {name} --repo {repo}`"))?;
-        if !out.success() {
-            anyhow::bail!(
-                "`gh label edit` failed: {}",
-                String::from_utf8_lossy(&out.stderr)
-            );
-        }
+        run_checked(
+            &self.runner,
+            &args,
+            None,
+            &format!("gh label edit {name} --repo {repo}"),
+        )?;
         Ok(())
     }
 
     fn delete_label(&self, repo: &str, name: &str) -> anyhow::Result<()> {
-        let out = self
-            .runner
-            .run(
-                &["label", "delete", name, "--repo", repo, "--confirm"],
-                None,
-            )
-            .with_context(|| format!("failed to spawn `gh label delete {name} --repo {repo}`"))?;
-        if !out.success() {
-            anyhow::bail!(
-                "`gh label delete` failed: {}",
-                String::from_utf8_lossy(&out.stderr)
-            );
-        }
+        run_checked(
+            &self.runner,
+            &["label", "delete", name, "--repo", repo, "--confirm"],
+            None,
+            &format!("gh label delete {name} --repo {repo}"),
+        )?;
         Ok(())
     }
 
@@ -493,24 +455,17 @@ impl<R: GhRunner> GhRepoClient for GhRepoClientImpl<R> {
     }
 
     fn delete_ruleset(&self, repo: &str, id: u64) -> anyhow::Result<()> {
-        let out = self
-            .runner
-            .run(
-                &[
-                    "api",
-                    "-X",
-                    "DELETE",
-                    &format!("repos/{repo}/rulesets/{id}"),
-                ],
-                None,
-            )
-            .with_context(|| format!("failed to spawn `gh api DELETE rulesets/{id}` for {repo}"))?;
-        if !out.success() {
-            anyhow::bail!(
-                "`gh api DELETE rulesets/{id}` failed: {}",
-                String::from_utf8_lossy(&out.stderr)
-            );
-        }
+        run_checked(
+            &self.runner,
+            &[
+                "api",
+                "-X",
+                "DELETE",
+                &format!("repos/{repo}/rulesets/{id}"),
+            ],
+            None,
+            &format!("DELETE repos/{repo}/rulesets/{id}"),
+        )?;
         Ok(())
     }
 
@@ -528,26 +483,17 @@ impl<R: GhRunner> GhRepoClient for GhRepoClientImpl<R> {
     }
 
     fn delete_branch_protection(&self, repo: &str, branch: &str) -> anyhow::Result<()> {
-        let out = self
-            .runner
-            .run(
-                &[
-                    "api",
-                    "-X",
-                    "DELETE",
-                    &format!("repos/{repo}/branches/{branch}/protection"),
-                ],
-                None,
-            )
-            .with_context(|| {
-                format!("failed to spawn `gh api DELETE branch protection` for {repo}/{branch}")
-            })?;
-        if !out.success() {
-            anyhow::bail!(
-                "`gh api DELETE branch protection` failed: {}",
-                String::from_utf8_lossy(&out.stderr)
-            );
-        }
+        run_checked(
+            &self.runner,
+            &[
+                "api",
+                "-X",
+                "DELETE",
+                &format!("repos/{repo}/branches/{branch}/protection"),
+            ],
+            None,
+            &format!("DELETE repos/{repo}/branches/{branch}/protection"),
+        )?;
         Ok(())
     }
 
@@ -616,7 +562,7 @@ fn execute_inner(
 ) -> ExitCode {
     // Resolve the effective manifest (upstream fetch + optional local overlay,
     // or just local file when --upstream-manifest is not given).
-    let fetcher = GhFetcher;
+    let fetcher = GhFetcher::new();
     let manifest =
         match upstream_manifest::resolve(effective_upstream_manifest, &args.manifest, &fetcher) {
             Ok(m) => m,
@@ -914,7 +860,7 @@ mod tests {
         let err = c.detect_repo().unwrap_err();
 
         // Assert
-        assert!(err.to_string().contains("`gh repo view` failed"));
+        assert!(err.to_string().contains("gh repo view failed"));
     }
 
     // ------------------------------------------------------------------
@@ -953,7 +899,7 @@ mod tests {
         let err = c.fetch_repo("owner/repo").unwrap_err();
 
         // Assert
-        assert!(err.to_string().contains("`gh api GET"));
+        assert!(err.to_string().contains("GET repos/owner/repo"));
     }
 
     // ------------------------------------------------------------------
@@ -1025,7 +971,7 @@ mod tests {
         let err = c.fetch_labels("owner/repo").unwrap_err();
 
         // Assert
-        assert!(err.to_string().contains("`gh label list` failed"));
+        assert!(err.to_string().contains("gh label list"));
     }
 
     // ------------------------------------------------------------------
@@ -1253,7 +1199,7 @@ mod tests {
         let err = c.fetch_branch_protection("owner/repo", "main").unwrap_err();
 
         // Assert
-        assert!(err.to_string().contains("branch protection failed"));
+        assert!(err.to_string().contains("branches/main/protection failed"));
     }
 
     // ------------------------------------------------------------------
@@ -1576,7 +1522,7 @@ mod tests {
             .unwrap_err();
 
         // Assert
-        assert!(err.to_string().contains("`gh label create` failed"));
+        assert!(err.to_string().contains("gh label create"));
     }
 
     #[test]
@@ -1803,7 +1749,10 @@ mod tests {
             .unwrap_err();
 
         // Assert
-        assert!(err.to_string().contains("DELETE branch protection"));
+        assert!(
+            err.to_string()
+                .contains("DELETE repos/owner/repo/branches/main/protection")
+        );
     }
 
     // ------------------------------------------------------------------
@@ -1915,10 +1864,7 @@ mod tests {
             .unwrap_err();
 
         // Assert
-        assert!(
-            err.to_string()
-                .contains("`gh api PATCH repos/owner/repo` failed")
-        );
+        assert!(err.to_string().contains("PATCH repos/owner/repo"));
     }
 
     // ------------------------------------------------------------------

--- a/crates/gh-sync/src/sync/runner.rs
+++ b/crates/gh-sync/src/sync/runner.rs
@@ -1,3 +1,5 @@
+use super::gh_error;
+
 /// Raw output from a `gh` CLI invocation.
 #[derive(Debug, Clone)]
 pub struct GhOutput {
@@ -57,6 +59,12 @@ impl GhRunner for SystemGhRunner {
         let mut cmd = std::process::Command::new("gh");
         cmd.args(args);
 
+        // When the tracing level is DEBUG or lower, propagate GH_DEBUG=api so
+        // the gh CLI emits its HTTP request/response trace to stderr.
+        if tracing::enabled!(tracing::Level::DEBUG) {
+            cmd.env("GH_DEBUG", "api");
+        }
+
         if stdin.is_some() {
             cmd.stdin(std::process::Stdio::piped());
         }
@@ -86,12 +94,128 @@ impl GhRunner for SystemGhRunner {
 }
 
 // ---------------------------------------------------------------------------
+// run_checked — structured error helper
+// ---------------------------------------------------------------------------
+
+/// Run `gh <args>` and return the output, or bail with a rich error on
+/// non-zero exit.
+///
+/// On failure this function:
+/// 1. Parses API error JSON from stdout/stderr via [`gh_error::parse_from_streams`].
+/// 2. Emits a structured `tracing::error!` with the full stdout/stderr bodies.
+/// 3. Bails with a human-readable message containing `op`, a tail-truncated
+///    stderr (≤ 2 KiB), and any parsed API-error fields.
+///
+/// `op` should be a short human-readable label such as `"PATCH repos/owner/repo"`.
+pub fn run_checked(
+    runner: &dyn GhRunner,
+    args: &[&str],
+    stdin: Option<&[u8]>,
+    op: &str,
+) -> anyhow::Result<GhOutput> {
+    if let Some(bytes) = stdin {
+        let body_len = bytes.len();
+        let preview_len = body_len.min(1024);
+        let body_preview = bytes
+            .get(..preview_len)
+            .and_then(|b| std::str::from_utf8(b).ok())
+            .map_or_else(|| "<binary>".to_owned(), str::to_owned);
+        tracing::debug!(%op, ?args, body_len, body_preview, "gh command stdin");
+    }
+
+    let out = runner.run(args, stdin)?;
+
+    if out.success() {
+        return Ok(out);
+    }
+
+    let exit_code = out.exit_code;
+    let stderr_full = String::from_utf8_lossy(&out.stderr);
+    let stdout_full = String::from_utf8_lossy(&out.stdout);
+    let api_error = gh_error::parse_from_streams(&out.stdout, &out.stderr);
+
+    tracing::error!(
+        %op,
+        ?args,
+        ?exit_code,
+        stderr = %stderr_full,
+        stdout = %stdout_full,
+        ?api_error,
+        "gh command failed"
+    );
+
+    let stderr_summary = gh_error::truncate_tail(&stderr_full, 2048);
+    let detail = build_error_detail(api_error.as_ref(), &stdout_full);
+
+    anyhow::bail!("{op} failed (exit {exit_code:?}): {stderr_summary}{detail}");
+}
+
+fn build_error_detail(api_error: Option<&gh_error::GhApiError>, stdout: &str) -> String {
+    api_error.map_or_else(
+        || {
+            if stdout.is_empty() {
+                String::new()
+            } else {
+                let stdout_summary = gh_error::truncate_tail(stdout, 2048);
+                format!(" [stdout: {stdout_summary}]")
+            }
+        },
+        |err| {
+            let mut parts: Vec<String> = Vec::new();
+            if let Some(msg) = &err.message {
+                parts.push(format!("message: {msg}"));
+            }
+            if let Some(status) = err.status {
+                parts.push(format!("HTTP {status}"));
+            }
+            if let Some(rid) = &err.request_id {
+                parts.push(format!("request_id={rid}"));
+            }
+            for fe in &err.errors {
+                let mut fparts: Vec<String> = Vec::new();
+                if let Some(r) = &fe.resource {
+                    fparts.push(format!("resource={r}"));
+                }
+                if let Some(f) = &fe.field {
+                    fparts.push(format!("field={f}"));
+                }
+                if let Some(c) = &fe.code {
+                    fparts.push(format!("code={c}"));
+                }
+                if let Some(m) = &fe.message {
+                    fparts.push(format!("msg={m}"));
+                }
+                if !fparts.is_empty() {
+                    parts.push(fparts.join(", "));
+                }
+            }
+            if parts.is_empty() {
+                String::new()
+            } else {
+                format!(" [{}]", parts.join("; "))
+            }
+        },
+    )
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Minimal mock runner for run_checked tests.
+    struct MockRunner {
+        output: GhOutput,
+    }
+
+    impl GhRunner for MockRunner {
+        fn run(&self, _args: &[&str], _stdin: Option<&[u8]>) -> anyhow::Result<GhOutput> {
+            Ok(self.output.clone())
+        }
+    }
 
     #[test]
     fn gh_output_success_true_on_zero() {
@@ -121,5 +245,96 @@ mod tests {
             stderr: vec![],
         };
         assert!(!out.success());
+    }
+
+    #[test]
+    fn run_checked_returns_ok_on_success() {
+        let runner = MockRunner {
+            output: GhOutput {
+                exit_code: Some(0),
+                stdout: b"ok".to_vec(),
+                stderr: vec![],
+            },
+        };
+        let result = run_checked(&runner, &["api", "repos/foo"], None, "GET repos/foo");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().stdout, b"ok");
+    }
+
+    #[test]
+    fn run_checked_error_includes_stderr_in_message() {
+        let runner = MockRunner {
+            output: GhOutput {
+                exit_code: Some(1),
+                stdout: vec![],
+                stderr: b"something went wrong".to_vec(),
+            },
+        };
+        let err = run_checked(&runner, &["api"], None, "GET foo")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("something went wrong"), "err={err}");
+    }
+
+    #[test]
+    fn run_checked_error_includes_api_error_fields_in_message() {
+        let runner = MockRunner {
+            output: GhOutput {
+                exit_code: Some(1),
+                stdout: br#"{"message":"Validation Failed","errors":[{"resource":"Repository","field":"merge_commit_title","code":"invalid"}],"status":"422"}"#.to_vec(),
+                stderr: b"gh: Validation Failed (HTTP 422)".to_vec(),
+            },
+        };
+        let err = run_checked(
+            &runner,
+            &["api", "-X", "PATCH", "repos/foo"],
+            None,
+            "PATCH repos/foo",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("Validation Failed"), "err={err}");
+        assert!(err.contains("merge_commit_title"), "err={err}");
+        assert!(err.contains("HTTP 422"), "err={err}");
+    }
+
+    #[test]
+    fn run_checked_truncates_large_stderr_in_bail() {
+        // 10 KiB stderr — bail message must be well under 3 KiB.
+        let large_stderr = vec![b'x'; 10 * 1024];
+        let runner = MockRunner {
+            output: GhOutput {
+                exit_code: Some(1),
+                stdout: vec![],
+                stderr: large_stderr,
+            },
+        };
+        let err = run_checked(&runner, &["api"], None, "PATCH foo")
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.len() < 3 * 1024,
+            "bail message too long: {} bytes",
+            err.len()
+        );
+        assert!(
+            err.contains("truncated"),
+            "should contain truncation notice; err={err}"
+        );
+    }
+
+    #[test]
+    fn run_checked_includes_stdout_when_no_api_error_parsed() {
+        let runner = MockRunner {
+            output: GhOutput {
+                exit_code: Some(1),
+                stdout: b"unexpected plain output".to_vec(),
+                stderr: b"exit 1".to_vec(),
+            },
+        };
+        let err = run_checked(&runner, &["api"], None, "GET bar")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("unexpected plain output"), "err={err}");
     }
 }

--- a/crates/gh-sync/src/sync/upstream.rs
+++ b/crates/gh-sync/src/sync/upstream.rs
@@ -4,6 +4,9 @@
 #[allow(clippy::module_name_repetitions)]
 pub use gh_sync_engine::upstream::{FetchResult, TreeEntry, UpstreamFetcher};
 
+use crate::sync::gh_error;
+use crate::sync::runner::{GhRunner, SystemGhRunner, run_checked};
+
 // ---------------------------------------------------------------------------
 // TreeResponse (internal — only used by GhFetcher below)
 // ---------------------------------------------------------------------------
@@ -19,51 +22,82 @@ struct TreeResponse {
 // ---------------------------------------------------------------------------
 
 /// Production implementation: calls `gh api` with a raw-content Accept header.
-#[derive(Debug)]
-pub struct GhFetcher;
+pub struct GhFetcher {
+    runner: Box<dyn GhRunner>,
+}
+
+impl std::fmt::Debug for GhFetcher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GhFetcher").finish_non_exhaustive()
+    }
+}
+
+impl GhFetcher {
+    /// Create with the real `gh` CLI.
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    pub fn new() -> Self {
+        Self {
+            runner: Box::new(SystemGhRunner),
+        }
+    }
+
+    /// Create with an injected runner (for tests).
+    #[cfg(test)]
+    pub fn with_runner(runner: impl GhRunner + 'static) -> Self {
+        Self {
+            runner: Box::new(runner),
+        }
+    }
+}
+
+impl Default for GhFetcher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl UpstreamFetcher for GhFetcher {
     // NOTEST(io): thin wrapper around the `gh` CLI binary — exercised via
     // integration tests only; unit tests use MockUpstreamFetcher instead.
     #[cfg_attr(coverage_nightly, coverage(off))]
     fn fetch(&self, repo: &str, ref_: &str, path: &str) -> anyhow::Result<FetchResult> {
-        use anyhow::Context as _;
-
         let url = format!("repos/{repo}/contents/{path}?ref={ref_}");
-        let output = std::process::Command::new("gh")
-            .args(["api", "-H", "Accept: application/vnd.github.raw", &url])
-            .output()
-            .context("failed to spawn `gh`")?;
+        let out = self.runner.run(
+            &["api", "-H", "Accept: application/vnd.github.raw", &url],
+            None,
+        )?;
 
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            if stderr.contains("HTTP 404") {
+        if !out.success() {
+            let api_err = gh_error::parse_from_streams(&out.stdout, &out.stderr);
+            let status = api_err.as_ref().and_then(|e| e.status);
+            let stderr_str = String::from_utf8_lossy(&out.stderr);
+            // 2-stage: API status first, string fallback.
+            if status == Some(404) || (status.is_none() && stderr_str.contains("HTTP 404")) {
                 return Ok(FetchResult::NotFound);
             }
-            anyhow::bail!("`gh api` failed: {stderr}");
+            let exit_code = out.exit_code;
+            let stdout_str = String::from_utf8_lossy(&out.stdout);
+            let op = format!("GET {url}");
+            tracing::error!(%op, ?exit_code, stderr = %stderr_str, stdout = %stdout_str, ?api_err, "gh command failed");
+            let stderr_summary = gh_error::truncate_tail(&stderr_str, 2048);
+            anyhow::bail!("{op} failed (exit {exit_code:?}): {stderr_summary}");
         }
 
-        Ok(FetchResult::Content(output.stdout))
+        Ok(FetchResult::Content(out.stdout))
     }
 
     // NOTEST(io): thin wrapper around the `gh` CLI binary — exercised via
     // integration tests only; unit tests use MockFetcher instead.
     #[cfg_attr(coverage_nightly, coverage(off))]
     fn resolve_tag_sha(&self, repo: &str, tag: &str) -> anyhow::Result<String> {
-        use anyhow::Context as _;
-
         let url = format!("repos/{repo}/commits/{tag}");
-        let output = std::process::Command::new("gh")
-            .args(["api", &url, "--jq", ".sha"])
-            .output()
-            .context("failed to spawn `gh`")?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!("`gh api` failed: {stderr}");
-        }
-
-        let sha = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+        let out = run_checked(
+            self.runner.as_ref(),
+            &["api", &url, "--jq", ".sha"],
+            None,
+            &format!("GET {url}"),
+        )?;
+        let sha = String::from_utf8_lossy(&out.stdout).trim().to_owned();
         Ok(sha)
     }
 
@@ -74,17 +108,14 @@ impl UpstreamFetcher for GhFetcher {
         use anyhow::Context as _;
 
         let url = format!("repos/{repo}/git/trees/{ref_}?recursive=1");
-        let output = std::process::Command::new("gh")
-            .args(["api", &url])
-            .output()
-            .context("failed to spawn `gh`")?;
+        let out = run_checked(
+            self.runner.as_ref(),
+            &["api", &url],
+            None,
+            &format!("GET {url}"),
+        )?;
 
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!("`gh api` failed: {stderr}");
-        }
-
-        let response = serde_json::from_slice::<TreeResponse>(&output.stdout)
+        let response = serde_json::from_slice::<TreeResponse>(&out.stdout)
             .context("failed to parse tree response JSON")?;
 
         if response.truncated {
@@ -98,5 +129,170 @@ impl UpstreamFetcher for GhFetcher {
             .into_iter()
             .filter(|e| e.type_ == "blob")
             .collect())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    use std::collections::VecDeque;
+    use std::sync::Mutex;
+
+    use crate::sync::runner::{GhOutput, GhRunner};
+
+    use super::*;
+
+    struct MockGhRunner {
+        queue: Mutex<VecDeque<GhOutput>>,
+    }
+
+    impl MockGhRunner {
+        fn new(responses: Vec<GhOutput>) -> Self {
+            Self {
+                queue: Mutex::new(responses.into()),
+            }
+        }
+
+        fn ok(stdout: impl Into<Vec<u8>>) -> Self {
+            Self::new(vec![GhOutput {
+                exit_code: Some(0),
+                stdout: stdout.into(),
+                stderr: vec![],
+            }])
+        }
+
+        fn fail_with(stdout: impl Into<Vec<u8>>, stderr: impl Into<Vec<u8>>) -> Self {
+            Self::new(vec![GhOutput {
+                exit_code: Some(1),
+                stdout: stdout.into(),
+                stderr: stderr.into(),
+            }])
+        }
+    }
+
+    impl GhRunner for MockGhRunner {
+        fn run(&self, _args: &[&str], _stdin: Option<&[u8]>) -> anyhow::Result<GhOutput> {
+            self.queue
+                .lock()
+                .unwrap()
+                .pop_front()
+                .ok_or_else(|| anyhow::anyhow!("MockGhRunner: no more responses queued"))
+        }
+    }
+
+    fn tree_json(entries: &[(&str, &str)], truncated: bool) -> Vec<u8> {
+        let tree: Vec<_> = entries
+            .iter()
+            .map(|(path, type_)| serde_json::json!({ "path": path, "type": type_ }))
+            .collect();
+        serde_json::to_vec(&serde_json::json!({ "tree": tree, "truncated": truncated })).unwrap()
+    }
+
+    // --- fetch tests ---
+
+    #[test]
+    fn fetch_success_returns_content() {
+        let runner = MockGhRunner::ok(b"file content".as_ref());
+        let fetcher = GhFetcher::with_runner(runner);
+        let result = fetcher.fetch("owner/repo", "main", "README.md").unwrap();
+        assert!(matches!(result, FetchResult::Content(ref c) if c == b"file content"));
+    }
+
+    #[test]
+    fn fetch_404_via_api_status_returns_not_found() {
+        let json_404 = serde_json::to_vec(&serde_json::json!({
+            "message": "Not Found",
+            "status": "404"
+        }))
+        .unwrap();
+        let runner = MockGhRunner::fail_with(json_404, b"gh: Not Found (HTTP 404)".as_ref());
+        let fetcher = GhFetcher::with_runner(runner);
+        let result = fetcher.fetch("owner/repo", "main", "missing.md").unwrap();
+        assert!(matches!(result, FetchResult::NotFound));
+    }
+
+    #[test]
+    fn fetch_404_via_stderr_string_returns_not_found() {
+        let runner = MockGhRunner::fail_with(vec![], b"HTTP 404 Not Found".as_ref());
+        let fetcher = GhFetcher::with_runner(runner);
+        let result = fetcher.fetch("owner/repo", "main", "missing.md").unwrap();
+        assert!(matches!(result, FetchResult::NotFound));
+    }
+
+    #[test]
+    fn fetch_non_404_error_returns_err() {
+        let runner = MockGhRunner::fail_with(vec![], b"gh: server error (HTTP 500)".as_ref());
+        let fetcher = GhFetcher::with_runner(runner);
+        let result = fetcher.fetch("owner/repo", "main", "file.md");
+        assert!(result.is_err());
+    }
+
+    // --- resolve_tag_sha tests ---
+
+    #[test]
+    fn resolve_tag_sha_returns_trimmed_sha() {
+        let runner = MockGhRunner::ok(b"abc123def456\n".as_ref());
+        let fetcher = GhFetcher::with_runner(runner);
+        let sha = fetcher.resolve_tag_sha("owner/repo", "v1.0.0").unwrap();
+        assert_eq!(sha, "abc123def456");
+    }
+
+    #[test]
+    fn resolve_tag_sha_error_returns_err() {
+        let runner = MockGhRunner::fail_with(vec![], b"gh: Not Found (HTTP 404)".as_ref());
+        let fetcher = GhFetcher::with_runner(runner);
+        let result = fetcher.resolve_tag_sha("owner/repo", "v9.9.9");
+        assert!(result.is_err());
+    }
+
+    // --- list_all_files tests ---
+
+    #[test]
+    fn list_all_files_returns_only_blobs() {
+        let json = tree_json(&[("src/main.rs", "blob"), ("src", "tree")], false);
+        let runner = MockGhRunner::ok(json);
+        let fetcher = GhFetcher::with_runner(runner);
+        let files = fetcher.list_all_files("owner/repo", "main").unwrap();
+        assert_eq!(files.len(), 1);
+        let first = files.first().unwrap();
+        assert_eq!(first.path, "src/main.rs");
+    }
+
+    #[test]
+    fn list_all_files_truncated_returns_err() {
+        let json = tree_json(&[("file.rs", "blob")], true);
+        let runner = MockGhRunner::ok(json);
+        let fetcher = GhFetcher::with_runner(runner);
+        let result = fetcher.list_all_files("owner/repo", "main");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("truncated"));
+    }
+
+    #[test]
+    fn list_all_files_api_error_returns_err() {
+        let runner =
+            MockGhRunner::fail_with(vec![], b"gh: internal server error (HTTP 500)".as_ref());
+        let fetcher = GhFetcher::with_runner(runner);
+        let result = fetcher.list_all_files("owner/repo", "main");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn list_all_files_invalid_json_returns_err() {
+        let runner = MockGhRunner::ok(b"not valid json".as_ref());
+        let fetcher = GhFetcher::with_runner(runner);
+        let result = fetcher.list_all_files("owner/repo", "main");
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("parse tree response")
+        );
     }
 }

--- a/mise.toml
+++ b/mise.toml
@@ -16,7 +16,7 @@ RUST_LOG = "warn,gh_sync=trace"
 "aqua:taiki-e/cargo-llvm-cov" = "0.8.5"
 "aqua:watchexec/cargo-watch" = "8.5.3"
 "cargo:cargo-sweep" = "0.8.0"
-"github:naa0yama/gh-sync" = "0.3.0"
+"github:naa0yama/gh-sync" = "0.3.3"
 "github:rust-secure-code/cargo-auditable" = "0.7.4"
 actionlint = "1.7.12"
 codeql = { version = "latest", bin_path = "codeql", platforms = { linux-x64 = { asset_pattern = "codeql-linux64.zip" }, macos-arm64 = { asset_pattern = "codeql-osx64.zip" }, macos-x64 = { asset_pattern = "codeql-osx64.zip" }, windows-x64 = { asset_pattern = "codeql-win64.zip" } } }


### PR DESCRIPTION
## Summary

- **HTTP 422 直接対処**: `apply.rs` の merge_commit / squash_merge_commit フィールドの strip 条件を保守的 (`!= Some(true)`) に変更。live 側で既に `allow_merge_commit=false` のリポジトリへの title/message PATCH が 422 になるパターンを防ぐ
- **診断基盤の整備**: `gh_error.rs` 新規追加 — `gh api` が stdout に出す API error JSON (message, errors[].field, HTTP status, request_id) をパース。全 bail! サイトを `run_checked()` に統一して構造化 `tracing::error!` と詳細エラーメッセージを提供
- **`GH_DEBUG=api` 自動伝搬**: `RUST_LOG=gh_sync=debug` で `gh` CLI の HTTP トレースが stderr に自動表示

## 変更の詳細

### fix(sync/repo): prevent HTTP 422 by conservative merge_commit/squash strip

過去コミット `c4ea443` と同クラスの 422 — live 側で merge commits が無効なリポに title/message をセットしようとするシナリオを修正。strip 条件を `== Some(false)` (狭い) から `!= Some(true)` (保守的、None も disabled 扱い) に変更。

**注記**: 422 の直接原因は診断ログ不足で確認できていない仮説。ただし後続コミットで入れた `gh_error.rs` + `run_checked` が即座に `errors[].field` を見せるため、万一別の 422 が残っていても即特定可能。

### feat(sync): add gh API error parser and run_checked helper

`gh api` は 4xx 時のエラー JSON を **stdout** に出力するが、従来の `bail!` は stderr のみを使用していた。`parse_from_streams()` で stdout 優先 + stderr フォールバックのパースを実装し、`run_checked()` ヘルパに統合。

### refactor(sync): replace all gh bail! sites with run_checked

repo.rs / detect.rs / upstream.rs / issue_sync/mod.rs / init/mod.rs の 24 箇所を `run_checked()` に統一。`GhFetcher` を unit struct から `Box<dyn GhRunner>` に変更して MockGhRunner を注入可能にし、upstream.rs に 10 件のユニットテストを追加。

## Test plan

- [x] `mise run test` — 553 テスト全 pass
- [x] `mise run pre-commit` — clean:sweep / fmt / clippy:strict / ast-grep / lint:gh 全 pass
- [ ] task-14: 実機で `cargo run -p gh-sync -- sync repo` を naa0yama/chezmage で実行して 422 解消を確認
- [ ] task-15: 意図的エラー注入で `errors[].field` が表示されることを確認