### PR TITLE
ci: fix ci-gate condition to suppress false pass on concurrency cancel

### DIFF
--- a/.github/workflows/_orchestrator.yaml
+++ b/.github/workflows/_orchestrator.yaml
@@ -220,7 +220,12 @@ jobs:
 
   ci-gate:
     name: CI Gate
-    if: always() && github.event.action != 'closed'
+    # !contains(...,'cancelled') suppresses the gate when concurrency
+    # cancel-in-progress cancels upstream jobs; skipped != cancelled.
+    if: >-
+      !cancelled()
+      && !contains(needs.*.result, 'cancelled')
+      && github.event.action != 'closed'
     needs: [rust-ci, miri, audit, container, docs-ci, codeql, actionlint]
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
## 概要
- `ci-gate` ジョブの `if:` 条件を `always()` から `!cancelled() && !contains(needs.*.result,'cancelled')` に変更
- `concurrency.cancel-in-progress: true` によって上流ジョブがキャンセルされた場合に `ci-gate` が誤って「通過」と判定されるバグを修正
- キャンセル時はゲートをスキップするよう動作を修正し、偽陽性の CI 通過を防ぐ

## テスト計画
- [x] `mise run pre-commit` が成功 (fmt, clippy, ast-grep, actionlint すべて通過)
- [ ] 並行実行のキャンセル時に ci-gate がスキップされることを確認 (GitHub Actions 上で動作確認)