### PR TITLE
ci: extract cleanup job into standalone workflow

### DIFF
--- a/.github/workflows/_orchestrator.yaml
+++ b/.github/workflows/_orchestrator.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened]
   schedule:
     - cron: "0 18 * * *" # daily at 03:00 JST
 
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   detect-changes:
     name: detect-changes
-    if: github.event_name == 'pull_request' && github.event.action != 'closed'
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -93,7 +93,6 @@ jobs:
       !cancelled()
       && (github.event_name == 'push'
           || (github.event_name == 'pull_request'
-              && github.event.action != 'closed'
               && needs.detect-changes.outputs.rust == 'true'))
     uses: ./.github/workflows/rust-ci.yaml
     permissions:
@@ -105,7 +104,6 @@ jobs:
     needs: detect-changes
     if: >-
       github.event_name == 'pull_request'
-      && github.event.action != 'closed'
       && needs.detect-changes.outputs.miri == 'true'
     uses: ./.github/workflows/miri.yaml
     permissions:
@@ -118,7 +116,6 @@ jobs:
     if: >-
       github.event_name == 'schedule'
       || (github.event_name == 'pull_request'
-          && github.event.action != 'closed'
           && needs.detect-changes.outputs.audit == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -135,7 +132,6 @@ jobs:
     needs: detect-changes
     if: >-
       github.event_name == 'pull_request'
-      && github.event.action != 'closed'
       && needs.detect-changes.outputs.container == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -155,7 +151,6 @@ jobs:
     needs: detect-changes
     if: >-
       github.event_name == 'pull_request'
-      && github.event.action != 'closed'
       && needs.detect-changes.outputs.docs == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -172,7 +167,7 @@ jobs:
     if: >-
       github.event_name == 'push'
       || github.event_name == 'schedule'
-      || (github.event_name == 'pull_request' && github.event.action != 'closed')
+      || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -188,7 +183,7 @@ jobs:
     name: actionlint
     if: >-
       github.event_name == 'schedule'
-      || (github.event_name == 'pull_request' && github.event.action != 'closed')
+      || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -201,23 +196,6 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/act-actionlint
 
-  cleanup:
-    name: cleanup
-    if: >-
-      github.event_name == 'pull_request'
-      && github.event.action == 'closed'
-      && github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    permissions:
-      actions: write # Required to manage GitHub Actions artifacts
-      packages: write # Required to delete package versions
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/act-cleanup
-
   ci-gate:
     name: CI Gate
     # !contains(...,'cancelled') suppresses the gate when concurrency
@@ -225,7 +203,6 @@ jobs:
     if: >-
       !cancelled()
       && !contains(needs.*.result, 'cancelled')
-      && github.event.action != 'closed'
     needs: [rust-ci, miri, audit, container, docs-ci, codeql, actionlint]
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Cleanup
+on:
+  pull_request:
+    types: [closed]
+
+permissions: {}
+
+concurrency:
+  group: cleanup-${{ github.event.pull_request.number }}
+  cancel-in-progress: false # zizmor: ignore[concurrency-limits] cleanup must run to completion after merge
+
+jobs:
+  cleanup:
+    name: cleanup
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      actions: write # Required to manage GitHub Actions artifacts
+      packages: write # Required to delete package versions
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/act-cleanup

--- a/mise.toml
+++ b/mise.toml
@@ -16,7 +16,7 @@ RUST_LOG = "warn,gh_sync=trace"
 "aqua:taiki-e/cargo-llvm-cov" = "0.8.5"
 "aqua:watchexec/cargo-watch" = "8.5.3"
 "cargo:cargo-sweep" = "0.8.0"
-"github:naa0yama/gh-sync" = "0.3.3"
+"github:naa0yama/gh-sync" = "0.3.4"
 "github:rust-secure-code/cargo-auditable" = "0.7.4"
 actionlint = "1.7.12"
 codeql = { version = "latest", bin_path = "codeql", platforms = { linux-x64 = { asset_pattern = "codeql-linux64.zip" }, macos-arm64 = { asset_pattern = "codeql-osx64.zip" }, macos-x64 = { asset_pattern = "codeql-osx64.zip" }, windows-x64 = { asset_pattern = "codeql-win64.zip" } } }


### PR DESCRIPTION
## Summary

- `_orchestrator.yaml` から `closed` イベントトリガーと `cleanup` job を削除
- `cleanup.yaml` を新設し、PR close/merge 専用ワークフローとして独立
- `event.action != 'closed'` ガード条件が不要になり、全 job の条件式がシンプルに
- `gh-sync` を `0.3.3` → `0.3.4` へバージョンアップ

## Test plan

- [ ] CI が通ること
- [ ] PR マージ後に `Cleanup` ワークフローが起動すること
- [ ] PR オープン・sync 時に `_orchestrator.yaml` の各 job が正常に動作すること