### PR TITLE
fix(ci): add explanatory comment to issues: write permission

### DIFF
--- a/.github/workflows/gh-sync.yaml
+++ b/.github/workflows/gh-sync.yaml
@@ -20,13 +20,13 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
-      issues: write # Required to create and update drift issues
+      issues: write # create and update drift-tracking issues
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      - uses: naa0yama/gh-sync@1e2635dbfc27e544c28b82ec6faeffd4450154ff # v0.3.2
+      - uses: naa0yama/gh-sync@923c8824aa5da62d93465d67af2ffe0dba49e9d7 # v0.3.4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           upstream-manifest: naa0yama/boilerplate-rust@main:.github/gh-sync/config.yaml

--- a/crates/gh-sync/src/init/workflow.rs
+++ b/crates/gh-sync/src/init/workflow.rs
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
-      issues: write
+      issues: write # create and update drift-tracking issues
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
## 概要

- `issues: write` パーミッションに説明コメント `# create and update drift-tracking issues` を追加
- 対象: ライブワークフロー (`.github/workflows/gh-sync.yaml`) と Rust 内埋め込みテンプレート (`crates/gh-sync/src/init/workflow.rs`)

## 背景

`zizmor` が説明コメントのないパーミッションを lint エラーとして検出するため、`mise run pre-commit` の `lint:gh` チェックが失敗していた。また、`cargo run -- init --downstream` で生成されるワークフローも同様の問題を持つテンプレートから生成されていた。

## テスト計画

- [ ] `mise run pre-commit` がすべてパスすること (特に `lint:gh` で "No findings to report")
- [ ] `cargo run -- init --downstream` で生成されるワークフローが zizmor に準拠していること