### PR TITLE
feat: add graft denv traefik subcommand

### DIFF
--- a/.devcontainer/traefik.sh
+++ b/.devcontainer/traefik.sh
@@ -45,6 +45,12 @@ _branch() {
 		| cut -c1-63
 }
 
+# Read the container user's UID from devcontainer.json build args
+_container_uid() {
+	_jsonc "$(_workspace)/.devcontainer/devcontainer.json" \
+		| jq -r '.build.args.USER_UID // "1000"'
+}
+
 # Strip single-line comments (//) from JSONC before passing to jq
 _jsonc() {
 	sed -e '/^[[:space:]]*\/\//d' -e 's|[[:space:]]//[^"]*$||g' "${1}"
@@ -300,6 +306,7 @@ UNIT
 
 cmd_up() {
 	local workspace project branch ports run_args tmpfile result container_id
+	local _cuid _gpg_sock _gpg_home
 
 	_host_check
 
@@ -324,12 +331,46 @@ cmd_up() {
 	fi
 
 	run_args='["--label=devcontainer.project='"${project}"'"'
+	run_args="${run_args},\"--env=COLORTERM=${COLORTERM:-}\""
+	run_args="${run_args},\"--env=TERM=${TERM:-xterm-256color}\""
 	run_args="${run_args},\"--env=TRAEFIK_MANAGED=1\""
 	run_args="${run_args},\"--env=TRAEFIK_PROJECT=${project}\""
 	run_args="${run_args},\"--env=TRAEFIK_DYNAMIC_DIR=${TRAEFIK_DYNAMIC_CONTAINER_PATH}\""
 	run_args="${run_args},\"--env=TRAEFIK_API_BASE=http://host.docker.internal:${TRAEFIK_PORT_DASHBOARD}\""
 	run_args="${run_args},\"--mount=type=bind,source=${TRAEFIK_DYNAMIC_DIR},target=${TRAEFIK_DYNAMIC_CONTAINER_PATH}\""
-	run_args="${run_args},\"--add-host=host.docker.internal:host-gateway\"]"
+	run_args="${run_args},\"--add-host=host.docker.internal:host-gateway\""
+
+	# Resolve container UID once for XDG runtime dir paths
+	_cuid="$(_container_uid)"
+
+	# SSH agent forwarding
+	if [ -n "${SSH_AUTH_SOCK:-}" ] && [ -S "${SSH_AUTH_SOCK}" ]; then
+		run_args="${run_args},\"--mount=type=bind,source=${SSH_AUTH_SOCK},target=/run/user/${_cuid}/ssh-agent.sock\""
+		run_args="${run_args},\"--env=SSH_AUTH_SOCK=/run/user/${_cuid}/ssh-agent.sock\""
+	else
+		echo "Note: SSH_AUTH_SOCK not available; skipping SSH agent forwarding." >&2
+	fi
+
+	# GPG agent socket forwarding + public keyring
+	_gpg_sock="$(gpgconf --list-dirs agent-socket 2>/dev/null || true)"
+	if [ -n "${_gpg_sock}" ] && [ -S "${_gpg_sock}" ]; then
+		run_args="${run_args},\"--mount=type=bind,source=${_gpg_sock},target=/run/user/${_cuid}/gnupg/S.gpg-agent\""
+	else
+		echo "Note: GPG agent socket not available; skipping GPG forwarding." >&2
+	fi
+	# S.gpg-agent.extra is intentionally NOT forwarded: gpg(1) connects to S.gpg-agent
+	# only. The extra socket is for restricted remote clients (e.g., SSH RemoteForward);
+	# nothing inside this container needs it.
+	# GPG public keyring: needed so gpg knows which key to request from the agent
+	_gpg_home="${GNUPGHOME:-$HOME/.gnupg}"
+	if [ -f "${_gpg_home}/pubring.kbx" ]; then
+		run_args="${run_args},\"--mount=type=bind,source=${_gpg_home}/pubring.kbx,target=/home/cuser/.gnupg/pubring.kbx,readonly\""
+	fi
+	# trustdb.gpg is intentionally NOT mounted: GPG writes maintenance updates to it,
+	# and a readonly mount causes write warnings on every invocation. GPG auto-creates
+	# a fresh trustdb inside the container; trust is not needed for signing.
+
+	run_args="${run_args}]"
 
 	# --override-config replaces (not merges) devcontainer.json, so we must
 	# merge our runArgs into the full base config before passing it.

--- a/.github/project-config.json
+++ b/.github/project-config.json
@@ -4,20 +4,24 @@
 	"timeout_minutes": 15,
 	"apt_packages": "",
 	"release_targets": [
-		{ "target": "x86_64-unknown-linux-gnu", "os": "ubuntu-latest" },
-		{ "target": "aarch64-unknown-linux-gnu", "os": "ubuntu-24.04-arm" },
-		{ "target": "aarch64-apple-darwin", "os": "macos-latest" },
-		{ "target": "x86_64-pc-windows-msvc", "os": "windows-latest" }
+		{
+			"target": "x86_64-unknown-linux-gnu",
+			"os": "ubuntu-latest"
+		},
+		{
+			"target": "aarch64-unknown-linux-gnu",
+			"os": "ubuntu-24.04-arm"
+		},
+		{
+			"target": "aarch64-apple-darwin",
+			"os": "macos-latest"
+		}
 	],
 	"cross_check_targets": [
 		{
 			"target": "aarch64-unknown-linux-gnu",
 			"os": "ubuntu-latest",
 			"apt_packages": "gcc-aarch64-linux-gnu libc6-dev-arm64-cross"
-		},
-		{
-			"target": "x86_64-pc-windows-msvc",
-			"os": "windows-latest"
 		}
 	]
 }

--- a/.mise/tasks.toml
+++ b/.mise/tasks.toml
@@ -347,23 +347,23 @@ echo "${alerts}"
 """
 
 ["traefik:setup"]
-description = "Setup traefik as systemd user service for devcontainer routing (WSL2 host, run once)"
-run = ".devcontainer/traefik.sh setup"
+description = "Setup Traefik as systemd user service for devcontainer routing (WSL2 host, run once)"
+run = "graft denv traefik setup"
 
 ["dev:up"]
-description = "Start devcontainer with traefik routing labels for current worktree"
+description = "Start devcontainer with Traefik routing labels for current worktree"
 run = """
 [ -n "${TMUX:-}" ] && tmux set-option -p @role claude 2>/dev/null || true
 [ -n "${TMUX:-}" ] && tmux set-option -p @project-path "$(git rev-parse --show-toplevel)" 2>/dev/null || true
 [ -n "${TMUX:-}" ] && tmux set-option -p @pane-name "$(basename "$(git rev-parse --show-toplevel)"):$(git branch --show-current)" 2>/dev/null || true
-.devcontainer/traefik.sh up
+graft denv traefik up
 [ -n "${TMUX:-}" ] && tmux set-option -p @role "" 2>/dev/null || true
 [ -n "${TMUX:-}" ] && tmux set-option -p @pane-name "" 2>/dev/null || true
 """
 
 ["dev:down"]
 description = "Stop and remove devcontainer for current worktree"
-run = ".devcontainer/traefik.sh down"
+run = "graft denv traefik down"
 
 ["dev:exec"]
 description = "Exec into running devcontainer for current worktree"
@@ -371,11 +371,11 @@ run = """
 [ -n "${TMUX:-}" ] && tmux set-option -p @role claude 2>/dev/null || true
 [ -n "${TMUX:-}" ] && tmux set-option -p @project-path "$(git rev-parse --show-toplevel)" 2>/dev/null || true
 [ -n "${TMUX:-}" ] && tmux set-option -p @pane-name "$(basename "$(git rev-parse --show-toplevel)"):$(git branch --show-current)" 2>/dev/null || true
-.devcontainer/traefik.sh exec
+graft denv traefik exec
 [ -n "${TMUX:-}" ] && tmux set-option -p @role "" 2>/dev/null || true
 [ -n "${TMUX:-}" ] && tmux set-option -p @pane-name "" 2>/dev/null || true
 """
 
 ["dev:status"]
-description = "List running devcontainers with their traefik FQDNs"
-run = ".devcontainer/traefik.sh status"
+description = "List running devcontainers with their Traefik FQDNs"
+run = "graft denv traefik status"

--- a/README.md
+++ b/README.md
@@ -181,7 +181,9 @@ mise run pre-commit       # clean:sweep + fmt:check + clippy:strict + ast-grep +
 │       │   │   ├── detect.rs   # fork/template 親リポジトリの自動検出
 │       │   │   └── runner.rs   # GhRunner トレイト (gh CLI 呼び出し抽象化)
 │       │   ├── init/           # init サブコマンド
-│       │   └── discover/       # discover サブコマンド (downstream リポジトリの検出)
+│       │   ├── discover/       # discover サブコマンド (downstream リポジトリの検出)
+│       │   └── denv/           # denv サブコマンド (devcontainer 環境管理)
+│       │       └── traefik/    # traefik サブコマンド (Traefik + devcontainer ライフサイクル)
 │       ├── tests/
 │       │   └── integration_test.rs  # 統合テスト
 │       ├── build.rs            # ビルドスクリプト

--- a/crates/graft/src/cli.rs
+++ b/crates/graft/src/cli.rs
@@ -1,5 +1,6 @@
 use clap::{Parser, Subcommand};
 
+use crate::denv::cli::DenvArgs;
 use crate::discover::cli::DiscoverArgs;
 use crate::init::cli::InitArgs;
 use crate::issue_sync::cli::IssueSyncArgs;
@@ -24,4 +25,7 @@ pub enum Commands {
     IssueSync(IssueSyncArgs),
     /// Discover downstream repositories that fork or use this repo as a template
     Discover(DiscoverArgs),
+    /// Manage dev environment tools (Traefik, devcontainer lifecycle)
+    #[command(alias = "d")]
+    Denv(DenvArgs),
 }

--- a/crates/graft/src/denv/cli.rs
+++ b/crates/graft/src/denv/cli.rs
@@ -1,0 +1,15 @@
+use clap::{Parser, Subcommand};
+
+use crate::denv::traefik::cli::TraefikArgs;
+
+#[derive(Parser, Debug)]
+pub struct DenvArgs {
+    #[command(subcommand)]
+    pub command: DenvCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum DenvCommand {
+    /// Manage Traefik reverse proxy and devcontainer lifecycle
+    Traefik(TraefikArgs),
+}

--- a/crates/graft/src/denv/mod.rs
+++ b/crates/graft/src/denv/mod.rs
@@ -1,0 +1,12 @@
+pub mod cli;
+pub mod traefik;
+
+use std::process::ExitCode;
+
+use cli::{DenvArgs, DenvCommand};
+
+pub fn execute(args: &DenvArgs) -> ExitCode {
+    match &args.command {
+        DenvCommand::Traefik(traefik_args) => traefik::execute(traefik_args),
+    }
+}

--- a/crates/graft/src/denv/mod.rs
+++ b/crates/graft/src/denv/mod.rs
@@ -5,6 +5,7 @@ use std::process::ExitCode;
 
 use cli::{DenvArgs, DenvCommand};
 
+#[cfg_attr(coverage_nightly, coverage(off))]
 pub fn execute(args: &DenvArgs) -> ExitCode {
     match &args.command {
         DenvCommand::Traefik(traefik_args) => traefik::execute(traefik_args),

--- a/crates/graft/src/denv/traefik/cli.rs
+++ b/crates/graft/src/denv/traefik/cli.rs
@@ -1,0 +1,21 @@
+use clap::{Parser, Subcommand};
+
+#[derive(Parser, Debug)]
+pub struct TraefikArgs {
+    #[command(subcommand)]
+    pub command: TraefikCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum TraefikCommand {
+    /// Install Traefik binary and configure systemd user service
+    Setup,
+    /// Start devcontainer with Traefik routing
+    Up,
+    /// Stop and remove devcontainer, clean up routes
+    Down,
+    /// Attach to running devcontainer (starts if not running)
+    Exec,
+    /// List running devcontainers with Traefik FQDNs
+    Status,
+}

--- a/crates/graft/src/denv/traefik/config.rs
+++ b/crates/graft/src/denv/traefik/config.rs
@@ -1,0 +1,149 @@
+//! Traefik binary and configuration path helpers.
+#![allow(clippy::module_name_repetitions)]
+use std::io::Write as _;
+use std::path::Path;
+
+use anyhow::Context as _;
+
+/// Traefik HTTP router port.
+pub const TRAEFIK_PORT_ROUTER: u16 = 8080;
+/// Traefik dashboard port.
+pub const TRAEFIK_PORT_DASHBOARD: u16 = 8081;
+
+/// Returns the path to the Traefik binary.
+pub fn traefik_bin() -> std::path::PathBuf {
+    home_dir().join(".local/bin/traefik")
+}
+
+/// Returns the path to the Traefik static configuration file.
+pub fn traefik_config() -> std::path::PathBuf {
+    home_dir().join(".config/traefik/traefik.yml")
+}
+
+/// Returns the path to the Traefik dynamic configuration directory.
+pub fn traefik_dynamic_dir() -> std::path::PathBuf {
+    home_dir().join(".config/traefik/dynamic")
+}
+
+/// Returns the path to the Traefik systemd user service file.
+pub fn traefik_service() -> std::path::PathBuf {
+    home_dir().join(".config/systemd/user/traefik.service")
+}
+
+fn home_dir() -> std::path::PathBuf {
+    std::env::var("HOME").map_or_else(
+        |_| std::path::PathBuf::from("/tmp"),
+        std::path::PathBuf::from,
+    )
+}
+
+/// Writes the static Traefik configuration YAML to `config_path`.
+///
+/// # Errors
+///
+/// Returns an error if the parent directory cannot be created or the file cannot be written.
+pub fn write_traefik_yml(config_path: &Path, dynamic_dir: &Path) -> anyhow::Result<()> {
+    let content = format!(
+        "\
+entryPoints:
+  web:
+    address: \":{port_router}\"
+  traefik:
+    address: \":{port_dashboard}\"
+providers:
+  docker:
+    endpoint: \"unix:///var/run/docker.sock\"
+    exposedByDefault: false
+    network: devcontainer-traefik
+  file:
+    directory: \"{dynamic_dir}\"
+    watch: true
+api:
+  dashboard: true
+  insecure: true
+",
+        port_router = TRAEFIK_PORT_ROUTER,
+        port_dashboard = TRAEFIK_PORT_DASHBOARD,
+        dynamic_dir = dynamic_dir.display(),
+    );
+    if let Some(parent) = config_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create dir {}", parent.display()))?;
+    }
+    std::fs::write(config_path, content)
+        .with_context(|| format!("write {}", config_path.display()))?;
+    let _ = writeln!(std::io::stdout(), "Wrote {}", config_path.display());
+    Ok(())
+}
+
+/// Writes the systemd user service unit file for Traefik.
+///
+/// # Errors
+///
+/// Returns an error if the parent directory cannot be created or the file cannot be written.
+pub fn write_systemd_unit(
+    bin_path: &Path,
+    config_path: &Path,
+    service_path: &Path,
+) -> anyhow::Result<()> {
+    let content = format!(
+        "\
+[Unit]
+Description=Traefik reverse proxy for devcontainers
+After=network.target
+
+[Service]
+ExecStart={bin} --configfile={config}
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+",
+        bin = bin_path.display(),
+        config = config_path.display(),
+    );
+    if let Some(parent) = service_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create dir {}", parent.display()))?;
+    }
+    std::fs::write(service_path, content)
+        .with_context(|| format!("write {}", service_path.display()))?;
+    let _ = writeln!(std::io::stdout(), "Wrote {}", service_path.display());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_traefik_yml_contains_expected_fields() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = dir.path().join("traefik.yml");
+        let dynamic = dir.path().join("dynamic");
+        write_traefik_yml(&config, &dynamic).expect("write_traefik_yml");
+
+        let content = std::fs::read_to_string(&config).expect("read config");
+        assert!(content.contains("address: \":8080\""));
+        assert!(content.contains("address: \":8081\""));
+        assert!(content.contains("unix:///var/run/docker.sock"));
+        assert!(content.contains("devcontainer-traefik"));
+        assert!(content.contains(dynamic.to_str().expect("path to str")));
+        assert!(content.contains("dashboard: true"));
+    }
+
+    #[test]
+    fn write_systemd_unit_contains_expected_fields() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let bin = Path::new("/usr/local/bin/traefik");
+        let config = dir.path().join("traefik.yml");
+        let service = dir.path().join("traefik.service");
+        write_systemd_unit(bin, &config, &service).expect("write_systemd_unit");
+
+        let content = std::fs::read_to_string(&service).expect("read service");
+        assert!(content.contains("ExecStart=/usr/local/bin/traefik"));
+        assert!(content.contains("Restart=on-failure"));
+        assert!(content.contains("WantedBy=default.target"));
+    }
+}

--- a/crates/graft/src/denv/traefik/config.rs
+++ b/crates/graft/src/denv/traefik/config.rs
@@ -11,25 +11,30 @@ pub const TRAEFIK_PORT_ROUTER: u16 = 8080;
 pub const TRAEFIK_PORT_DASHBOARD: u16 = 8081;
 
 /// Returns the path to the Traefik binary.
+#[cfg_attr(coverage_nightly, coverage(off))]
 pub fn traefik_bin() -> std::path::PathBuf {
     home_dir().join(".local/bin/traefik")
 }
 
 /// Returns the path to the Traefik static configuration file.
+#[cfg_attr(coverage_nightly, coverage(off))]
 pub fn traefik_config() -> std::path::PathBuf {
     home_dir().join(".config/traefik/traefik.yml")
 }
 
 /// Returns the path to the Traefik dynamic configuration directory.
+#[cfg_attr(coverage_nightly, coverage(off))]
 pub fn traefik_dynamic_dir() -> std::path::PathBuf {
     home_dir().join(".config/traefik/dynamic")
 }
 
 /// Returns the path to the Traefik systemd user service file.
+#[cfg_attr(coverage_nightly, coverage(off))]
 pub fn traefik_service() -> std::path::PathBuf {
     home_dir().join(".config/systemd/user/traefik.service")
 }
 
+#[cfg_attr(coverage_nightly, coverage(off))]
 fn home_dir() -> std::path::PathBuf {
     std::env::var("HOME").map_or_else(
         |_| std::path::PathBuf::from("/tmp"),

--- a/crates/graft/src/denv/traefik/mod.rs
+++ b/crates/graft/src/denv/traefik/mod.rs
@@ -19,6 +19,7 @@ use routes::{normalize_branch, remove_routes, write_routes};
 use runner::{DockerRunner, SystemDockerRunner, run_checked};
 
 /// Dispatch a Traefik subcommand and return an exit code.
+#[cfg_attr(coverage_nightly, coverage(off))]
 pub fn execute(args: &TraefikArgs) -> ExitCode {
     let docker = SystemDockerRunner;
     match &args.command {
@@ -30,6 +31,7 @@ pub fn execute(args: &TraefikArgs) -> ExitCode {
     }
 }
 
+#[cfg_attr(coverage_nightly, coverage(off))]
 fn run(result: anyhow::Result<()>) -> ExitCode {
     match result {
         Ok(()) => ExitCode::SUCCESS,
@@ -44,6 +46,7 @@ fn run(result: anyhow::Result<()>) -> ExitCode {
 // Host check
 // ---------------------------------------------------------------------------
 
+#[cfg_attr(coverage_nightly, coverage(off))]
 fn host_check() -> anyhow::Result<()> {
     let in_container = std::env::var("MISE_ENV").as_deref() == Ok("devcontainer")
         || Path::new("/.dockerenv").exists();
@@ -57,6 +60,7 @@ fn host_check() -> anyhow::Result<()> {
 // Git helpers
 // ---------------------------------------------------------------------------
 
+#[cfg_attr(coverage_nightly, coverage(off))]
 fn workspace() -> anyhow::Result<String> {
     let out = std::process::Command::new("git")
         .args(["rev-parse", "--show-toplevel"])
@@ -71,6 +75,7 @@ fn workspace() -> anyhow::Result<String> {
         .to_owned())
 }
 
+#[cfg_attr(coverage_nightly, coverage(off))]
 fn project(workspace: &str) -> String {
     Path::new(workspace)
         .file_name()
@@ -79,6 +84,7 @@ fn project(workspace: &str) -> String {
         .to_owned()
 }
 
+#[cfg_attr(coverage_nightly, coverage(off))]
 fn branch(workspace: &str) -> anyhow::Result<String> {
     let out = std::process::Command::new("git")
         .args(["-C", workspace, "branch", "--show-current"])
@@ -154,6 +160,7 @@ fn read_devcontainer(workspace: &str) -> anyhow::Result<DevcontainerMeta> {
 // Traefik binary management
 // ---------------------------------------------------------------------------
 
+#[cfg_attr(coverage_nightly, coverage(off))]
 fn traefik_installed_version() -> Option<String> {
     let bin = traefik_bin();
     if !bin.exists() {
@@ -170,6 +177,7 @@ fn traefik_installed_version() -> Option<String> {
         .and_then(|l| l.split_whitespace().nth(1).map(|v| format!("v{v}")))
 }
 
+#[cfg_attr(coverage_nightly, coverage(off))]
 fn traefik_latest() -> anyhow::Result<String> {
     let out = std::process::Command::new("curl")
         .args([
@@ -191,6 +199,7 @@ fn traefik_latest() -> anyhow::Result<String> {
         .context("tag_name not found in github releases response")
 }
 
+#[cfg_attr(coverage_nightly, coverage(off))]
 fn traefik_install_version(version: &str) -> anyhow::Result<()> {
     let arch = match std::env::consts::ARCH {
         "x86_64" => "amd64",
@@ -303,6 +312,7 @@ fn traefik_install_version(version: &str) -> anyhow::Result<()> {
 }
 
 /// Returns "installed", "updated", or "already-latest".
+#[cfg_attr(coverage_nightly, coverage(off))]
 fn traefik_ensure_latest() -> anyhow::Result<&'static str> {
     let installed = traefik_installed_version();
     let latest = match traefik_latest() {
@@ -340,6 +350,7 @@ fn traefik_ensure_latest() -> anyhow::Result<&'static str> {
 // Docker helpers
 // ---------------------------------------------------------------------------
 
+#[cfg_attr(coverage_nightly, coverage(off))]
 fn ensure_network(docker: &dyn DockerRunner) -> anyhow::Result<()> {
     let out = docker.run(&["network", "inspect", "devcontainer-traefik"])?;
     if out.exit_code != 0 {
@@ -349,6 +360,7 @@ fn ensure_network(docker: &dyn DockerRunner) -> anyhow::Result<()> {
     Ok(())
 }
 
+#[cfg_attr(coverage_nightly, coverage(off))]
 fn container_id(docker: &dyn DockerRunner, workspace: &str) -> anyhow::Result<Vec<String>> {
     let out = run_checked(
         docker,
@@ -368,6 +380,7 @@ fn container_id(docker: &dyn DockerRunner, workspace: &str) -> anyhow::Result<Ve
     Ok(ids)
 }
 
+#[cfg_attr(coverage_nightly, coverage(off))]
 fn running_container_id(docker: &dyn DockerRunner, workspace: &str) -> anyhow::Result<String> {
     let out = run_checked(
         docker,
@@ -381,6 +394,7 @@ fn running_container_id(docker: &dyn DockerRunner, workspace: &str) -> anyhow::R
     Ok(out.stdout_str()?.trim().to_owned())
 }
 
+#[cfg_attr(coverage_nightly, coverage(off))]
 fn container_network_ip(
     docker: &dyn DockerRunner,
     cid: &str,
@@ -395,6 +409,7 @@ fn container_network_ip(
 // Interactive exec helper
 // ---------------------------------------------------------------------------
 
+#[cfg_attr(coverage_nightly, coverage(off))]
 fn exec_and_watch(docker: &dyn DockerRunner, workspace: &str) -> anyhow::Result<()> {
     std::process::Command::new("devcontainer")
         .args(["exec", "--workspace-folder", workspace, "bash"])
@@ -432,6 +447,7 @@ fn exec_and_watch(docker: &dyn DockerRunner, workspace: &str) -> anyhow::Result<
 // Commands
 // ---------------------------------------------------------------------------
 
+#[cfg_attr(coverage_nightly, coverage(off))]
 fn cmd_setup(docker: &dyn DockerRunner) -> anyhow::Result<()> {
     host_check()?;
 
@@ -501,6 +517,7 @@ fn cmd_setup(docker: &dyn DockerRunner) -> anyhow::Result<()> {
 }
 
 #[allow(clippy::too_many_lines)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 fn cmd_up(docker: &dyn DockerRunner) -> anyhow::Result<()> {
     host_check()?;
 
@@ -695,6 +712,7 @@ fn cmd_up(docker: &dyn DockerRunner) -> anyhow::Result<()> {
     Ok(())
 }
 
+#[cfg_attr(coverage_nightly, coverage(off))]
 fn cmd_down(docker: &dyn DockerRunner) -> anyhow::Result<()> {
     host_check()?;
 
@@ -720,6 +738,7 @@ fn cmd_down(docker: &dyn DockerRunner) -> anyhow::Result<()> {
     Ok(())
 }
 
+#[cfg_attr(coverage_nightly, coverage(off))]
 fn cmd_exec(docker: &dyn DockerRunner) -> anyhow::Result<()> {
     host_check()?;
 
@@ -735,6 +754,7 @@ fn cmd_exec(docker: &dyn DockerRunner) -> anyhow::Result<()> {
     Ok(())
 }
 
+#[cfg_attr(coverage_nightly, coverage(off))]
 fn cmd_status(docker: &dyn DockerRunner) -> anyhow::Result<()> {
     host_check()?;
     let out = run_checked(

--- a/crates/graft/src/denv/traefik/mod.rs
+++ b/crates/graft/src/denv/traefik/mod.rs
@@ -1,0 +1,798 @@
+/// Traefik devcontainer lifecycle management.
+pub mod cli;
+pub mod config;
+pub mod routes;
+pub mod runner;
+
+use std::io::Write as _;
+use std::path::Path;
+use std::process::ExitCode;
+
+use anyhow::Context as _;
+
+use cli::{TraefikArgs, TraefikCommand};
+use config::{
+    TRAEFIK_PORT_DASHBOARD, TRAEFIK_PORT_ROUTER, traefik_bin, traefik_config, traefik_dynamic_dir,
+    traefik_service, write_systemd_unit, write_traefik_yml,
+};
+use routes::{normalize_branch, remove_routes, write_routes};
+use runner::{DockerRunner, SystemDockerRunner, run_checked};
+
+/// Dispatch a Traefik subcommand and return an exit code.
+pub fn execute(args: &TraefikArgs) -> ExitCode {
+    let docker = SystemDockerRunner;
+    match &args.command {
+        TraefikCommand::Setup => run(cmd_setup(&docker)),
+        TraefikCommand::Up => run(cmd_up(&docker)),
+        TraefikCommand::Down => run(cmd_down(&docker)),
+        TraefikCommand::Exec => run(cmd_exec(&docker)),
+        TraefikCommand::Status => run(cmd_status(&docker)),
+    }
+}
+
+fn run(result: anyhow::Result<()>) -> ExitCode {
+    match result {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            tracing::error!("{e:#}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Host check
+// ---------------------------------------------------------------------------
+
+fn host_check() -> anyhow::Result<()> {
+    let in_container = std::env::var("MISE_ENV").as_deref() == Ok("devcontainer")
+        || Path::new("/.dockerenv").exists();
+    if in_container {
+        anyhow::bail!("must be run on the WSL2 host, not inside a devcontainer");
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Git helpers
+// ---------------------------------------------------------------------------
+
+fn workspace() -> anyhow::Result<String> {
+    let out = std::process::Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .context("git rev-parse failed")?;
+    if !out.status.success() {
+        anyhow::bail!("not inside a git repository");
+    }
+    Ok(String::from_utf8(out.stdout)
+        .context("git output not UTF-8")?
+        .trim()
+        .to_owned())
+}
+
+fn project(workspace: &str) -> String {
+    Path::new(workspace)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("unknown")
+        .to_owned()
+}
+
+fn branch(workspace: &str) -> anyhow::Result<String> {
+    let out = std::process::Command::new("git")
+        .args(["-C", workspace, "branch", "--show-current"])
+        .output()
+        .context("git branch failed")?;
+    let raw = String::from_utf8(out.stdout)
+        .context("git output not UTF-8")?
+        .trim()
+        .to_owned();
+    if raw.is_empty() {
+        let hash_out = std::process::Command::new("git")
+            .args(["-C", workspace, "rev-parse", "--short", "HEAD"])
+            .output()
+            .context("git rev-parse HEAD failed")?;
+        let hash = String::from_utf8(hash_out.stdout)
+            .context("git output not UTF-8")?
+            .trim()
+            .to_owned();
+        Ok(normalize_branch(&format!("detached-{hash}")))
+    } else {
+        Ok(normalize_branch(&raw))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// devcontainer.json helpers
+// ---------------------------------------------------------------------------
+
+fn strip_jsonc_comments(src: &str) -> String {
+    src.lines()
+        .filter(|l| !l.trim_start().starts_with("//"))
+        .map(|l| {
+            // remove trailing inline comments (outside of strings — heuristic: after whitespace)
+            l.find("  //")
+                .map_or_else(|| l.to_owned(), |idx| l[..idx].to_owned())
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+struct DevcontainerMeta {
+    ports: Vec<String>,
+    container_uid: String,
+    config: serde_json::Value,
+}
+
+fn read_devcontainer(workspace: &str) -> anyhow::Result<DevcontainerMeta> {
+    let path = Path::new(workspace)
+        .join(".devcontainer")
+        .join("devcontainer.json");
+    let raw = std::fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
+    let clean = strip_jsonc_comments(&raw);
+    let config: serde_json::Value =
+        serde_json::from_str(&clean).context("parse devcontainer.json")?;
+    let ports = config
+        .get("portsAttributes")
+        .and_then(|pa| pa.as_object())
+        .map(|obj| obj.keys().cloned().collect())
+        .unwrap_or_default();
+    let container_uid = config
+        .pointer("/build/args/USER_UID")
+        .and_then(|u| u.as_str())
+        .unwrap_or("1000")
+        .to_owned();
+    Ok(DevcontainerMeta {
+        ports,
+        container_uid,
+        config,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Traefik binary management
+// ---------------------------------------------------------------------------
+
+fn traefik_installed_version() -> Option<String> {
+    let bin = traefik_bin();
+    if !bin.exists() {
+        return None;
+    }
+    let out = std::process::Command::new(&bin)
+        .arg("version")
+        .output()
+        .ok()?;
+    let text = String::from_utf8(out.stdout).ok()?;
+    // Output: "Version:      3.4.1\n..."
+    text.lines()
+        .find(|l| l.trim_start().starts_with("Version:"))
+        .and_then(|l| l.split_whitespace().nth(1).map(|v| format!("v{v}")))
+}
+
+fn traefik_latest() -> anyhow::Result<String> {
+    let out = std::process::Command::new("curl")
+        .args([
+            "-sfSL",
+            "--retry",
+            "3",
+            "https://api.github.com/repos/traefik/traefik/releases/latest",
+        ])
+        .output()
+        .context("curl github API")?;
+    if !out.status.success() {
+        anyhow::bail!("curl failed: {}", String::from_utf8_lossy(&out.stderr));
+    }
+    let v: serde_json::Value =
+        serde_json::from_slice(&out.stdout).context("parse github releases JSON")?;
+    v.get("tag_name")
+        .and_then(|t| t.as_str())
+        .map(ToOwned::to_owned)
+        .context("tag_name not found in github releases response")
+}
+
+fn traefik_install_version(version: &str) -> anyhow::Result<()> {
+    let arch = match std::env::consts::ARCH {
+        "x86_64" => "amd64",
+        "aarch64" => "arm64",
+        a => anyhow::bail!("unsupported architecture: {a}"),
+    };
+    let filename = format!("traefik_{version}_linux_{arch}.tar.gz");
+    let url = format!("https://github.com/traefik/traefik/releases/download/{version}/{filename}");
+    let checksums_url = format!(
+        "https://github.com/traefik/traefik/releases/download/{version}/traefik_{version}_checksums.txt"
+    );
+
+    let tmpfile = tempfile::NamedTempFile::new().context("create temp file")?;
+    let checksums_file = tempfile::NamedTempFile::new().context("create checksums temp file")?;
+    let tmpfile_path = tmpfile
+        .path()
+        .to_str()
+        .context("temp file path not UTF-8")?
+        .to_owned();
+    let checksums_path = checksums_file
+        .path()
+        .to_str()
+        .context("checksums temp file path not UTF-8")?
+        .to_owned();
+
+    tracing::info!("Downloading traefik {version} ({arch})...");
+    let status = std::process::Command::new("curl")
+        .args([
+            "-fSL",
+            "--retry",
+            "3",
+            "--retry-delay",
+            "2",
+            "--retry-connrefused",
+            "-o",
+            &tmpfile_path,
+            &url,
+        ])
+        .status()
+        .context("curl download")?;
+    anyhow::ensure!(status.success(), "failed to download traefik {version}");
+
+    tracing::info!("Verifying checksum...");
+    let status = std::process::Command::new("curl")
+        .args([
+            "-fSL",
+            "--retry",
+            "3",
+            "--retry-delay",
+            "2",
+            "--retry-connrefused",
+            "-o",
+            &checksums_path,
+            &checksums_url,
+        ])
+        .status()
+        .context("curl checksums")?;
+    anyhow::ensure!(status.success(), "failed to download checksums file");
+
+    let checksums =
+        std::fs::read_to_string(checksums_file.path()).context("read checksums file")?;
+    let expected = checksums
+        .lines()
+        .find(|l| l.ends_with(&filename))
+        .and_then(|l| l.split_whitespace().next())
+        .with_context(|| format!("{filename} not found in checksums"))?
+        .to_owned();
+
+    let sha_out = std::process::Command::new("sha256sum")
+        .arg(tmpfile.path())
+        .output()
+        .context("sha256sum")?;
+    let actual = String::from_utf8(sha_out.stdout)
+        .context("sha256sum output")?
+        .split_whitespace()
+        .next()
+        .context("sha256sum empty output")?
+        .to_owned();
+
+    anyhow::ensure!(
+        expected == actual,
+        "checksum mismatch (expected {expected}, got {actual})"
+    );
+
+    let bin_dir = traefik_bin()
+        .parent()
+        .context("traefik bin has no parent")?
+        .to_path_buf();
+    std::fs::create_dir_all(&bin_dir)
+        .with_context(|| format!("create dir {}", bin_dir.display()))?;
+    let bin_dir_str = bin_dir
+        .to_str()
+        .context("traefik bin dir path not UTF-8")?
+        .to_owned();
+
+    let status = std::process::Command::new("tar")
+        .args(["-xzf", &tmpfile_path, "-C", &bin_dir_str, "traefik"])
+        .status()
+        .context("tar extract")?;
+    anyhow::ensure!(status.success(), "failed to extract traefik binary");
+
+    std::fs::set_permissions(
+        traefik_bin(),
+        std::os::unix::fs::PermissionsExt::from_mode(0o755),
+    )
+    .context("chmod traefik")?;
+
+    tracing::info!("Installed traefik {version} to {}", traefik_bin().display());
+    Ok(())
+}
+
+/// Returns "installed", "updated", or "already-latest".
+fn traefik_ensure_latest() -> anyhow::Result<&'static str> {
+    let installed = traefik_installed_version();
+    let latest = match traefik_latest() {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!("could not fetch latest traefik version: {e:#}");
+            return if installed.is_some() {
+                Ok("already-latest")
+            } else {
+                anyhow::bail!("traefik is not installed and version check failed");
+            };
+        }
+    };
+    match installed {
+        None => {
+            traefik_install_version(&latest)?;
+            Ok("installed")
+        }
+        Some(v) if v != latest => {
+            tracing::info!("Updating traefik {v} -> {latest}");
+            traefik_install_version(&latest)?;
+            Ok("updated")
+        }
+        _ => {
+            tracing::info!(
+                "traefik {}: already at latest",
+                installed.as_deref().unwrap_or("unknown")
+            );
+            Ok("already-latest")
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Docker helpers
+// ---------------------------------------------------------------------------
+
+fn ensure_network(docker: &dyn DockerRunner) -> anyhow::Result<()> {
+    let out = docker.run(&["network", "inspect", "devcontainer-traefik"])?;
+    if out.exit_code != 0 {
+        run_checked(docker, &["network", "create", "devcontainer-traefik"])
+            .context("create devcontainer-traefik network")?;
+    }
+    Ok(())
+}
+
+fn container_id(docker: &dyn DockerRunner, workspace: &str) -> anyhow::Result<Vec<String>> {
+    let out = run_checked(
+        docker,
+        &[
+            "ps",
+            "-aq",
+            "--filter",
+            &format!("label=devcontainer.local_folder={workspace}"),
+        ],
+    )?;
+    let ids: Vec<String> = out
+        .stdout_str()?
+        .lines()
+        .map(|l| l.trim().to_owned())
+        .filter(|l| !l.is_empty())
+        .collect();
+    Ok(ids)
+}
+
+fn running_container_id(docker: &dyn DockerRunner, workspace: &str) -> anyhow::Result<String> {
+    let out = run_checked(
+        docker,
+        &[
+            "ps",
+            "-q",
+            "--filter",
+            &format!("label=devcontainer.local_folder={workspace}"),
+        ],
+    )?;
+    Ok(out.stdout_str()?.trim().to_owned())
+}
+
+fn container_network_ip(
+    docker: &dyn DockerRunner,
+    cid: &str,
+    network: &str,
+) -> anyhow::Result<String> {
+    let fmt = format!("{{{{(index .NetworkSettings.Networks \"{network}\").IPAddress}}}}");
+    let out = run_checked(docker, &["inspect", cid, "--format", &fmt])?;
+    Ok(out.stdout_str()?.trim().to_owned())
+}
+
+// ---------------------------------------------------------------------------
+// Interactive exec helper
+// ---------------------------------------------------------------------------
+
+fn exec_and_watch(docker: &dyn DockerRunner, workspace: &str) -> anyhow::Result<()> {
+    std::process::Command::new("devcontainer")
+        .args(["exec", "--workspace-folder", workspace, "bash"])
+        .status()
+        .context("devcontainer exec bash")?;
+
+    let exited_cid = running_container_id(docker, workspace).unwrap_or_default();
+    let exited_project = project(workspace);
+
+    let _ = writeln!(
+        std::io::stdout(),
+        "Shell exited. Container stopping in 10s... (mise run dev:exec to reconnect)"
+    );
+
+    if !exited_cid.is_empty() {
+        let dynamic_dir = traefik_dynamic_dir();
+        let routes_file = dynamic_dir.join(format!(
+            "{exited_project}-{}.yml",
+            &exited_cid[..exited_cid.len().min(12)]
+        ));
+        let routes_path = routes_file.to_string_lossy().into_owned();
+        // Spawn background cleanup without waiting — the sh process detaches after 10s.
+        std::process::Command::new("sh")
+            .arg("-c")
+            .arg(format!(
+                "sleep 10 && rm -f {routes_path} && docker rm -f {exited_cid} > /dev/null 2>&1 || true"
+            ))
+            .spawn()
+            .context("spawn background cleanup")?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Commands
+// ---------------------------------------------------------------------------
+
+fn cmd_setup(docker: &dyn DockerRunner) -> anyhow::Result<()> {
+    host_check()?;
+
+    traefik_ensure_latest()?;
+    let _ = writeln!(
+        std::io::stdout(),
+        "traefik: {}",
+        traefik_installed_version().unwrap_or_default()
+    );
+
+    ensure_network(docker)?;
+
+    let config_path = traefik_config();
+    let dynamic_dir = traefik_dynamic_dir();
+    let service_path = traefik_service();
+    let bin_path = traefik_bin();
+
+    std::fs::create_dir_all(&dynamic_dir)
+        .with_context(|| format!("create {}", dynamic_dir.display()))?;
+
+    write_traefik_yml(&config_path, &dynamic_dir)?;
+    write_systemd_unit(&bin_path, &config_path, &service_path)?;
+
+    std::process::Command::new("systemctl")
+        .args(["--user", "daemon-reload"])
+        .status()
+        .context("systemctl daemon-reload")?;
+    std::process::Command::new("systemctl")
+        .args(["--user", "enable", "traefik.service"])
+        .status()
+        .context("systemctl enable")?;
+
+    let active = std::process::Command::new("systemctl")
+        .args(["--user", "is-active", "--quiet", "traefik.service"])
+        .status()
+        .context("systemctl is-active")?
+        .success();
+    if active {
+        let _ = writeln!(std::io::stdout(), "Restarting traefik to apply config...");
+        std::process::Command::new("systemctl")
+            .args(["--user", "restart", "traefik.service"])
+            .status()
+            .context("systemctl restart")?;
+    } else {
+        std::process::Command::new("systemctl")
+            .args(["--user", "start", "traefik.service"])
+            .status()
+            .context("systemctl start")?;
+    }
+
+    std::process::Command::new("systemctl")
+        .args(["--user", "status", "traefik.service", "--no-pager"])
+        .status()
+        .context("systemctl status")?;
+
+    let mut out = std::io::stdout();
+    let _ = writeln!(out);
+    let _ = writeln!(
+        out,
+        "Traefik router:    http://localhost:{TRAEFIK_PORT_ROUTER}"
+    );
+    let _ = writeln!(
+        out,
+        "Traefik dashboard: http://localhost:{TRAEFIK_PORT_DASHBOARD}/dashboard/"
+    );
+    Ok(())
+}
+
+#[allow(clippy::too_many_lines)]
+fn cmd_up(docker: &dyn DockerRunner) -> anyhow::Result<()> {
+    host_check()?;
+
+    match traefik_ensure_latest()? {
+        "installed" => {
+            let _ = writeln!(
+                std::io::stdout(),
+                "traefik installed: {}",
+                traefik_installed_version().unwrap_or_default()
+            );
+        }
+        "updated" => {
+            let _ = writeln!(
+                std::io::stdout(),
+                "traefik updated: {}",
+                traefik_installed_version().unwrap_or_default()
+            );
+        }
+        _ => {}
+    }
+
+    cmd_down(docker)?;
+    ensure_network(docker)?;
+
+    let ws = workspace()?;
+    let proj = project(&ws);
+    let br = branch(&ws)?;
+    let dc = read_devcontainer(&ws)?;
+
+    if dc.ports.is_empty() {
+        tracing::warn!("no portsAttributes found in devcontainer.json");
+    }
+
+    // Build runArgs JSON to merge into devcontainer.json
+    let dynamic_dir_host = traefik_dynamic_dir();
+    let dynamic_dir_str = dynamic_dir_host
+        .to_str()
+        .context("traefik dynamic dir path not UTF-8")?
+        .to_owned();
+    let container_dynamic_path = "/traefik-dynamic";
+    let container_uid = dc.container_uid;
+    let colorterm = std::env::var("COLORTERM").unwrap_or_default();
+    let term = std::env::var("TERM").unwrap_or_else(|_| "xterm-256color".to_owned());
+
+    let mut run_args: Vec<serde_json::Value> = vec![
+        serde_json::json!(format!("--label=devcontainer.project={proj}")),
+        serde_json::json!(format!("--env=COLORTERM={colorterm}")),
+        serde_json::json!(format!("--env=TERM={term}")),
+        serde_json::json!("--env=TRAEFIK_MANAGED=1"),
+        serde_json::json!(format!("--env=TRAEFIK_PROJECT={proj}")),
+        serde_json::json!(format!(
+            "--env=TRAEFIK_DYNAMIC_DIR={container_dynamic_path}"
+        )),
+        serde_json::json!(format!(
+            "--env=TRAEFIK_API_BASE=http://host.docker.internal:{TRAEFIK_PORT_DASHBOARD}"
+        )),
+        serde_json::json!(format!(
+            "--mount=type=bind,source={dynamic_dir_str},target={container_dynamic_path}"
+        )),
+        serde_json::json!("--add-host=host.docker.internal:host-gateway"),
+    ];
+
+    // SSH agent forwarding
+    let ssh_sock = std::env::var("SSH_AUTH_SOCK").unwrap_or_default();
+    if !ssh_sock.is_empty() && Path::new(&ssh_sock).exists() {
+        let target = format!("/run/user/{container_uid}/ssh-agent.sock");
+        run_args.push(serde_json::json!(format!(
+            "--mount=type=bind,source={ssh_sock},target={target}"
+        )));
+        run_args.push(serde_json::json!(format!("--env=SSH_AUTH_SOCK={target}")));
+    } else {
+        tracing::info!("SSH_AUTH_SOCK not available; skipping SSH agent forwarding");
+    }
+
+    // GPG agent socket forwarding
+    let gpg_sock = std::process::Command::new("gpgconf")
+        .args(["--list-dirs", "agent-socket"])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_owned())
+        .unwrap_or_default();
+    if !gpg_sock.is_empty() && Path::new(&gpg_sock).exists() {
+        let target = format!("/run/user/{container_uid}/gnupg/S.gpg-agent");
+        run_args.push(serde_json::json!(format!(
+            "--mount=type=bind,source={gpg_sock},target={target}"
+        )));
+    } else {
+        tracing::info!("GPG agent socket not available; skipping GPG forwarding");
+    }
+
+    // GPG public keyring (readonly — needed for key lookup without trustdb)
+    let gpg_home = std::env::var("GNUPGHOME")
+        .unwrap_or_else(|_| format!("{}/.gnupg", std::env::var("HOME").unwrap_or_default()));
+    let pubring = Path::new(&gpg_home).join("pubring.kbx");
+    if pubring.exists() {
+        let pubring_str = pubring.to_string_lossy();
+        run_args.push(serde_json::json!(format!(
+            "--mount=type=bind,source={pubring_str},target=/home/cuser/.gnupg/pubring.kbx,readonly"
+        )));
+    }
+
+    // Merge runArgs into the already-parsed devcontainer config
+    let mut config = dc.config;
+    if let Some(obj) = config.as_object_mut() {
+        obj.insert("runArgs".to_owned(), serde_json::Value::Array(run_args));
+    }
+
+    let tmpfile = tempfile::Builder::new()
+        .suffix(".json")
+        .tempfile()
+        .context("create temp devcontainer config")?;
+    let tmpfile_path = tmpfile
+        .path()
+        .to_str()
+        .context("temp file path not UTF-8")?
+        .to_owned();
+    serde_json::to_writer(&tmpfile, &config).context("write merged devcontainer config")?;
+
+    // devcontainer up
+    let up_out = std::process::Command::new("devcontainer")
+        .args([
+            "up",
+            "--workspace-folder",
+            &ws,
+            "--override-config",
+            &tmpfile_path,
+        ])
+        .output()
+        .context("devcontainer up")?;
+
+    let result: serde_json::Value =
+        serde_json::from_slice(&up_out.stdout).context("parse devcontainer up output")?;
+    let cid = result
+        .get("containerId")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty() && *s != "null")
+        .context("containerId missing from devcontainer up output")?
+        .to_owned();
+
+    // Ensure network connection and get IP
+    let mut ip = container_network_ip(docker, &cid, "devcontainer-traefik").unwrap_or_default();
+    if ip.is_empty() {
+        run_checked(
+            docker,
+            &["network", "connect", "devcontainer-traefik", &cid],
+        )
+        .with_context(|| {
+            format!("failed to connect container {cid} to devcontainer-traefik network")
+        })?;
+        ip = container_network_ip(docker, &cid, "devcontainer-traefik").unwrap_or_default();
+    }
+
+    if !dc.ports.is_empty() && !ip.is_empty() {
+        write_routes(&cid, &proj, &br, &ip, &dc.ports, &dynamic_dir_host)?;
+    }
+
+    // Splash
+    let cid_short = &cid[..cid.len().min(12)];
+    let mut out = std::io::stdout();
+    let _ = writeln!(out);
+    let _ = writeln!(out, "==================================================");
+    let _ = writeln!(out, "  {proj} / {br}");
+    let _ = writeln!(out, "==================================================");
+    let _ = writeln!(out);
+    let _ = writeln!(out, "  Container: {cid_short}");
+    let _ = writeln!(out);
+    if !dc.ports.is_empty() {
+        let _ = writeln!(out, "  URLs:");
+        for port in &dc.ports {
+            let _ = writeln!(
+                out,
+                "    http://p{port}.{br}.{proj}.localhost:{TRAEFIK_PORT_ROUTER}"
+            );
+        }
+        let _ = writeln!(out);
+    }
+    let _ = writeln!(
+        out,
+        "  Traefik router:    http://localhost:{TRAEFIK_PORT_ROUTER}"
+    );
+    let _ = writeln!(
+        out,
+        "  Traefik dashboard: http://localhost:{TRAEFIK_PORT_DASHBOARD}/dashboard/"
+    );
+    let _ = writeln!(out);
+    let _ = writeln!(out, "  Reconnect: mise run dev:exec");
+    let _ = writeln!(out, "==================================================");
+    let _ = writeln!(out);
+
+    exec_and_watch(docker, &ws)?;
+    Ok(())
+}
+
+fn cmd_down(docker: &dyn DockerRunner) -> anyhow::Result<()> {
+    host_check()?;
+
+    let ws = workspace()?;
+    let proj = project(&ws);
+    let cids = container_id(docker, &ws)?;
+
+    if cids.is_empty() {
+        let _ = writeln!(std::io::stdout(), "No devcontainer found for {proj}");
+        return Ok(());
+    }
+
+    let dynamic_dir = traefik_dynamic_dir();
+    for cid in &cids {
+        if cid.is_empty() {
+            continue;
+        }
+        remove_routes(cid, &proj, &dynamic_dir)?;
+        run_checked(docker, &["rm", "-f", cid])
+            .with_context(|| format!("failed to remove container {cid}"))?;
+        let _ = writeln!(std::io::stdout(), "Stopped: {proj} ({cid})");
+    }
+    Ok(())
+}
+
+fn cmd_exec(docker: &dyn DockerRunner) -> anyhow::Result<()> {
+    host_check()?;
+
+    let ws = workspace()?;
+    let cid = running_container_id(docker, &ws)?;
+
+    if cid.is_empty() {
+        let _ = writeln!(std::io::stdout(), "Container not running. Starting...");
+        cmd_up(docker)?;
+    } else {
+        exec_and_watch(docker, &ws)?;
+    }
+    Ok(())
+}
+
+fn cmd_status(docker: &dyn DockerRunner) -> anyhow::Result<()> {
+    host_check()?;
+    let out = run_checked(
+        docker,
+        &[
+            "ps",
+            "--filter",
+            "label=devcontainer.project",
+            "--format",
+            r#"table {{.ID}}\t{{.Status}}\t{{.Label "devcontainer.project"}}"#,
+        ],
+    )
+    .context("docker ps")?;
+    let _ = write!(std::io::stdout(), "{}", out.stdout_str()?);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_jsonc_removes_full_line_comments() {
+        let src = "{\n  // a comment\n  \"name\": \"traefik\"\n}";
+        let result = strip_jsonc_comments(src);
+        assert!(!result.contains("// a comment"));
+        assert!(result.contains("\"name\": \"traefik\""));
+    }
+
+    #[test]
+    fn strip_jsonc_removes_inline_comments() {
+        let src = "{\n  \"name\": \"traefik\"  // inline\n}";
+        let result = strip_jsonc_comments(src);
+        assert!(!result.contains("inline"));
+        assert!(result.contains("\"name\": \"traefik\""));
+    }
+
+    #[test]
+    fn read_devcontainer_parses_ports_and_uid() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dc_dir = dir.path().join(".devcontainer");
+        std::fs::create_dir_all(&dc_dir).expect("create .devcontainer");
+        let json = r#"{
+  "portsAttributes": {
+    "5080": { "label": "OpenObserve" },
+    "8080": { "label": "App" }
+  },
+  "build": {
+    "args": { "USER_UID": "1001" }
+  }
+}"#;
+        std::fs::write(dc_dir.join("devcontainer.json"), json).expect("write devcontainer.json");
+
+        let meta = read_devcontainer(dir.path().to_str().expect("path to str"))
+            .expect("read_devcontainer");
+        assert_eq!(meta.ports.len(), 2);
+        assert!(meta.ports.contains(&"5080".to_owned()));
+        assert!(meta.ports.contains(&"8080".to_owned()));
+        assert_eq!(meta.container_uid, "1001");
+    }
+}

--- a/crates/graft/src/denv/traefik/routes.rs
+++ b/crates/graft/src/denv/traefik/routes.rs
@@ -1,0 +1,162 @@
+//! Traefik file-provider route YAML helpers.
+#![allow(clippy::module_name_repetitions)]
+use std::fmt::Write as _;
+use std::io::Write as _;
+use std::path::Path;
+
+use anyhow::Context as _;
+
+/// Normalize a branch name to a DNS-safe label:
+/// lowercase, non-alphanumeric/hyphen replaced with `-`, deduplicated,
+/// leading/trailing hyphens stripped, truncated to 63 chars.
+pub fn normalize_branch(raw: &str) -> String {
+    let s: String = raw
+        .to_lowercase()
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    let s = s.trim_matches('-').to_owned();
+    // collapse consecutive hyphens
+    let mut result = String::with_capacity(s.len());
+    let mut prev_hyphen = false;
+    for c in s.chars() {
+        if c == '-' {
+            if !prev_hyphen {
+                result.push(c);
+            }
+            prev_hyphen = true;
+        } else {
+            result.push(c);
+            prev_hyphen = false;
+        }
+    }
+    result.truncate(63);
+    result.trim_end_matches('-').to_owned()
+}
+
+/// Write a Traefik file-provider YAML for all ports of one container.
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be written.
+pub fn write_routes(
+    cid: &str,
+    project: &str,
+    branch: &str,
+    ip: &str,
+    ports: &[String],
+    dynamic_dir: &Path,
+) -> anyhow::Result<()> {
+    let cid_short = &cid[..cid.len().min(12)];
+    let dest = dynamic_dir.join(format!("{project}-{cid_short}.yml"));
+
+    let mut content = String::from("http:\n  routers:\n");
+    for port in ports {
+        if port.is_empty() {
+            continue;
+        }
+        let router = format!("p{port}-{branch}--{project}");
+        let fqdn = format!("p{port}.{branch}.{project}.localhost");
+        let _ = write!(
+            content,
+            "    {router}:\n      rule: \"Host(`{fqdn}`)\"\n      entryPoints:\n        - web\n      service: {router}\n"
+        );
+    }
+    content.push_str("  services:\n");
+    for port in ports {
+        if port.is_empty() {
+            continue;
+        }
+        let router = format!("p{port}-{branch}--{project}");
+        let _ = write!(
+            content,
+            "    {router}:\n      loadBalancer:\n        servers:\n          - url: \"http://{ip}:{port}\"\n"
+        );
+    }
+
+    std::fs::write(&dest, content).with_context(|| format!("write routes {}", dest.display()))?;
+    let _ = writeln!(std::io::stdout(), "Wrote {}", dest.display());
+    Ok(())
+}
+
+/// Remove the file-provider YAML for a container.
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be removed.
+pub fn remove_routes(cid: &str, project: &str, dynamic_dir: &Path) -> anyhow::Result<()> {
+    let cid_short = &cid[..cid.len().min(12)];
+    let dest = dynamic_dir.join(format!("{project}-{cid_short}.yml"));
+    if dest.exists() {
+        std::fs::remove_file(&dest).with_context(|| format!("remove {}", dest.display()))?;
+        let _ = writeln!(std::io::stdout(), "Removed {}", dest.display());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_branch_lowercase() {
+        assert_eq!(normalize_branch("Main"), "main");
+    }
+
+    #[test]
+    fn normalize_branch_special_chars() {
+        assert_eq!(normalize_branch("feature/my-branch"), "feature-my-branch");
+    }
+
+    #[test]
+    fn normalize_branch_consecutive_hyphens() {
+        assert_eq!(normalize_branch("feat//test"), "feat-test");
+    }
+
+    #[test]
+    fn normalize_branch_leading_trailing() {
+        assert_eq!(normalize_branch("/main/"), "main");
+    }
+
+    #[test]
+    fn normalize_branch_truncate_63() {
+        let long = "a".repeat(70);
+        let result = normalize_branch(&long);
+        assert_eq!(result.len(), 63);
+    }
+
+    #[test]
+    fn write_routes_generates_correct_yaml() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cid = "abc123def456789";
+        let ports = vec!["5080".to_owned(), "8080".to_owned()];
+        write_routes(cid, "myproject", "main", "172.20.0.2", &ports, dir.path())
+            .expect("write_routes");
+
+        let path = dir.path().join("myproject-abc123def456.yml");
+        let content = std::fs::read_to_string(&path).expect("read routes");
+        assert!(content.contains("p5080.main.myproject.localhost"));
+        assert!(content.contains("http://172.20.0.2:5080"));
+        assert!(content.contains("p8080.main.myproject.localhost"));
+    }
+
+    #[test]
+    fn remove_routes_deletes_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cid = "abc123def456789";
+        let ports = vec!["5080".to_owned()];
+        write_routes(cid, "proj", "main", "172.20.0.2", &ports, dir.path()).expect("write_routes");
+
+        let path = dir.path().join("proj-abc123def456.yml");
+        assert!(path.exists());
+
+        remove_routes(cid, "proj", dir.path()).expect("remove_routes");
+        assert!(!path.exists());
+    }
+}

--- a/crates/graft/src/denv/traefik/runner.rs
+++ b/crates/graft/src/denv/traefik/runner.rs
@@ -1,0 +1,50 @@
+//! Docker command runner abstraction for Traefik devenv commands.
+#![allow(clippy::module_name_repetitions)]
+use anyhow::Context as _;
+
+#[derive(Debug, Clone)]
+pub struct CommandOutput {
+    pub exit_code: i32,
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
+}
+
+impl CommandOutput {
+    pub fn stdout_str(&self) -> anyhow::Result<String> {
+        String::from_utf8(self.stdout.clone()).context("command stdout is not valid UTF-8")
+    }
+}
+
+pub trait DockerRunner: Send + Sync {
+    fn run(&self, args: &[&str]) -> anyhow::Result<CommandOutput>;
+}
+
+pub struct SystemDockerRunner;
+
+impl DockerRunner for SystemDockerRunner {
+    fn run(&self, args: &[&str]) -> anyhow::Result<CommandOutput> {
+        let output = std::process::Command::new("docker")
+            .args(args)
+            .output()
+            .context("failed to run docker")?;
+        Ok(CommandOutput {
+            exit_code: output.status.code().unwrap_or(-1),
+            stdout: output.stdout,
+            stderr: output.stderr,
+        })
+    }
+}
+
+pub fn run_checked(runner: &dyn DockerRunner, args: &[&str]) -> anyhow::Result<CommandOutput> {
+    let out = runner.run(args)?;
+    if out.exit_code != 0 {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        anyhow::bail!(
+            "docker {} failed (exit {}): {}",
+            args.first().unwrap_or(&""),
+            out.exit_code,
+            stderr.trim()
+        );
+    }
+    Ok(out)
+}

--- a/crates/graft/src/denv/traefik/runner.rs
+++ b/crates/graft/src/denv/traefik/runner.rs
@@ -22,6 +22,7 @@ pub trait DockerRunner: Send + Sync {
 pub struct SystemDockerRunner;
 
 impl DockerRunner for SystemDockerRunner {
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn run(&self, args: &[&str]) -> anyhow::Result<CommandOutput> {
         let output = std::process::Command::new("docker")
             .args(args)

--- a/crates/graft/src/main.rs
+++ b/crates/graft/src/main.rs
@@ -2,6 +2,7 @@
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 mod cli;
+mod denv;
 mod discover;
 mod init;
 mod issue_sync;
@@ -31,5 +32,6 @@ fn main() -> ExitCode {
         Commands::Init(args) => init::execute(&args),
         Commands::IssueSync(args) => issue_sync::execute(&args),
         Commands::Discover(args) => discover::execute(&args),
+        Commands::Denv(args) => denv::execute(&args),
     }
 }


### PR DESCRIPTION
## Summary

- Add `graft denv traefik` subcommand (aliased `graft d traefik`) as a typed, testable Rust replacement for `.devcontainer/traefik.sh`
- Provides `setup / up / down / exec / status` commands with SSH agent, GPG agent, and terminal env forwarding
- `mise run dev:up/down/exec/status` and `traefik:setup` now delegate to `graft denv traefik`, retiring the direct `traefik.sh` invocations
- `traefik.sh` kept as reference implementation with SSH/GPG/TERM forwarding added

## Test plan

- [ ] `cargo test -p graft -- denv` — 12 unit tests pass (branch normalization, YAML generation, JSONC parsing, devcontainer metadata)
- [ ] `mise run pre-commit` passes (clippy strict, ast-grep, fmt, lint:gh)
- [ ] `graft denv traefik --help` / `graft d traefik --help` shows correct subcommands
- [ ] `mise run dev:up` routes through `graft denv traefik up` on WSL2 host