### PR TITLE
refactor: migrate marker tokens from gh-sync:keep-* to graft:keep-*

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,21 +7,21 @@
 		{
 			"type": "lldb",
 			"request": "launch",
-			// gh-sync:keep-start
+			// graft:keep-start
 			"name": "Debug executable 'graft'",
-			// gh-sync:keep-end
+			// graft:keep-end
 			"cargo": {
 				"args": [
 					"build",
-					// gh-sync:keep-start
+					// graft:keep-start
 					"--bin=graft",
 					"--package=graft"
-					// gh-sync:keep-end
+					// graft:keep-end
 				],
 				"filter": {
-					// gh-sync:keep-start
+					// graft:keep-start
 					"name": "graft",
-					// gh-sync:keep-end
+					// graft:keep-end
 					"kind": "bin"
 				}
 			},
@@ -31,22 +31,22 @@
 		{
 			"type": "lldb",
 			"request": "launch",
-			// gh-sync:keep-start
+			// graft:keep-start
 			"name": "Debug unit tests in executable 'graft'",
-			// gh-sync:keep-end
+			// graft:keep-end
 			"cargo": {
 				"args": [
 					"test",
 					"--no-run",
-					// gh-sync:keep-start
+					// graft:keep-start
 					"--bin=graft",
 					"--package=graft"
-					// gh-sync:keep-end
+					// graft:keep-end
 				],
 				"filter": {
-					// gh-sync:keep-start
+					// graft:keep-start
 					"name": "graft",
-					// gh-sync:keep-end
+					// graft:keep-end
 					"kind": "bin"
 				}
 			},

--- a/crates/graft-engine/src/mode/ci_check.rs
+++ b/crates/graft-engine/src/mode/ci_check.rs
@@ -525,7 +525,7 @@ mod tests {
         // Arrange: local has a marker block; upstream has no markers (just baseline).
         // After merge the expected = upstream_stripped + local_blocks = local → no drift.
         let dir = tempfile::tempdir().unwrap();
-        let marker_block = b"# gh-sync:keep-start\nb = local\n# gh-sync:keep-end\n";
+        let marker_block = b"# graft:keep-start\nb = local\n# graft:keep-end\n";
         let local_content = [b"a = 1\n".as_slice(), marker_block.as_slice()].concat();
         std::fs::write(dir.path().join("cfg.toml"), &local_content).unwrap();
 
@@ -557,7 +557,7 @@ mod tests {
     fn ci_check_replace_preserve_markers_reports_drift_when_non_marker_differs() {
         // Arrange: upstream changed; local has stale non-marker content.
         let dir = tempfile::tempdir().unwrap();
-        let marker_block = b"# gh-sync:keep-start\nb = local\n# gh-sync:keep-end\n";
+        let marker_block = b"# graft:keep-start\nb = local\n# graft:keep-end\n";
         let local_content = [b"a = old\n".as_slice(), marker_block.as_slice()].concat();
         std::fs::write(dir.path().join("cfg.toml"), &local_content).unwrap();
 

--- a/crates/graft-engine/src/mode/sync.rs
+++ b/crates/graft-engine/src/mode/sync.rs
@@ -571,7 +571,7 @@ mod tests {
     fn sync_replace_preserve_markers_writes_merged_content() {
         // Arrange: local file has a marker block that should survive after sync.
         let dir = tempfile::tempdir().unwrap();
-        let marker_block = b"# gh-sync:keep-start\nb = local\n# gh-sync:keep-end\n";
+        let marker_block = b"# graft:keep-start\nb = local\n# graft:keep-end\n";
         let local_content = [b"a = old\n".as_slice(), marker_block.as_slice()].concat();
         std::fs::write(dir.path().join("cfg.toml"), &local_content).unwrap();
 

--- a/crates/graft-engine/src/strategy/markers.rs
+++ b/crates/graft-engine/src/strategy/markers.rs
@@ -188,21 +188,20 @@ mod tests {
 
     #[test]
     fn strip_single_block_at_start() {
-        let input =
-            b"# gh-sync:keep-start\nversion = \"0.2.1\"\n# gh-sync:keep-end\nother = true\n";
+        let input = b"# graft:keep-start\nversion = \"0.2.1\"\n# graft:keep-end\nother = true\n";
         let (stripped, blocks) = strip_marker_blocks(input).unwrap();
         assert_eq!(stripped, b"other = true\n");
         assert_eq!(blocks.len(), 1);
         assert_eq!(blocks[0].position, 0);
         assert_eq!(
             blocks[0].content,
-            b"# gh-sync:keep-start\nversion = \"0.2.1\"\n# gh-sync:keep-end\n"
+            b"# graft:keep-start\nversion = \"0.2.1\"\n# graft:keep-end\n"
         );
     }
 
     #[test]
     fn strip_single_block_in_middle() {
-        let input = b"a = 1\nb = 2\n# gh-sync:keep-start\nc = 3\n# gh-sync:keep-end\nd = 4\n";
+        let input = b"a = 1\nb = 2\n# graft:keep-start\nc = 3\n# graft:keep-end\nd = 4\n";
         let (stripped, blocks) = strip_marker_blocks(input).unwrap();
         assert_eq!(stripped, b"a = 1\nb = 2\nd = 4\n");
         assert_eq!(blocks.len(), 1);
@@ -211,7 +210,7 @@ mod tests {
 
     #[test]
     fn strip_two_blocks() {
-        let input = b"# gh-sync:keep-start\nA\n# gh-sync:keep-end\nmid\n# gh-sync:keep-start\nB\n# gh-sync:keep-end\nend\n";
+        let input = b"# graft:keep-start\nA\n# graft:keep-end\nmid\n# graft:keep-start\nB\n# graft:keep-end\nend\n";
         let (stripped, blocks) = strip_marker_blocks(input).unwrap();
         assert_eq!(stripped, b"mid\nend\n");
         assert_eq!(blocks.len(), 2);
@@ -233,8 +232,7 @@ mod tests {
 
     #[test]
     fn merge_round_trips_single_block() {
-        let input =
-            b"# gh-sync:keep-start\nversion = \"0.2.1\"\n# gh-sync:keep-end\nother = true\n";
+        let input = b"# graft:keep-start\nversion = \"0.2.1\"\n# graft:keep-end\nother = true\n";
         let (stripped, blocks) = strip_marker_blocks(input).unwrap();
         let restored = merge_marker_blocks(&stripped, &blocks);
         assert_eq!(restored, input);
@@ -242,7 +240,7 @@ mod tests {
 
     #[test]
     fn merge_round_trips_two_blocks() {
-        let input = b"# gh-sync:keep-start\nA\n# gh-sync:keep-end\nmid\n# gh-sync:keep-start\nB\n# gh-sync:keep-end\nend\n";
+        let input = b"# graft:keep-start\nA\n# graft:keep-end\nmid\n# graft:keep-start\nB\n# graft:keep-end\nend\n";
         let (stripped, blocks) = strip_marker_blocks(input).unwrap();
         let restored = merge_marker_blocks(&stripped, &blocks);
         assert_eq!(restored, input);
@@ -261,20 +259,20 @@ mod tests {
 
     #[test]
     fn orphan_start_returns_unbalanced() {
-        let input = b"# gh-sync:keep-start\na = 1\n";
+        let input = b"# graft:keep-start\na = 1\n";
         assert_eq!(strip_marker_blocks(input), Err(MarkerError::Unbalanced));
     }
 
     #[test]
     fn orphan_end_returns_unbalanced() {
-        let input = b"a = 1\n# gh-sync:keep-end\n";
+        let input = b"a = 1\n# graft:keep-end\n";
         assert_eq!(strip_marker_blocks(input), Err(MarkerError::Unbalanced));
     }
 
     #[test]
     fn nested_start_returns_nested() {
         let input =
-            b"# gh-sync:keep-start\n# gh-sync:keep-start\ninner\n# gh-sync:keep-end\n# gh-sync:keep-end\n";
+            b"# graft:keep-start\n# graft:keep-start\ninner\n# graft:keep-end\n# graft:keep-end\n";
         assert_eq!(strip_marker_blocks(input), Err(MarkerError::Nested));
     }
 
@@ -291,10 +289,7 @@ mod tests {
 
     #[test]
     fn select_local_empty_returns_upstream() {
-        let upstream = vec![make_block(
-            0,
-            b"# gh-sync:keep-start\na\n# gh-sync:keep-end\n",
-        )];
+        let upstream = vec![make_block(0, b"# graft:keep-start\na\n# graft:keep-end\n")];
         let local: Vec<MarkerBlock> = vec![];
         let result = select_marker_blocks(upstream.clone(), local);
         assert_eq!(result, upstream);
@@ -304,11 +299,11 @@ mod tests {
     fn select_local_non_empty_returns_local() {
         let upstream = vec![make_block(
             0,
-            b"# gh-sync:keep-start\nupstream\n# gh-sync:keep-end\n",
+            b"# graft:keep-start\nupstream\n# graft:keep-end\n",
         )];
         let local = vec![make_block(
             0,
-            b"# gh-sync:keep-start\nlocal\n# gh-sync:keep-end\n",
+            b"# graft:keep-start\nlocal\n# graft:keep-end\n",
         )];
         let result = select_marker_blocks(upstream, local.clone());
         assert_eq!(result, local);
@@ -326,7 +321,7 @@ mod tests {
 
     #[test]
     fn jsonc_style_markers_are_recognised() {
-        let input = b"{\n// gh-sync:keep-start\n\"name\": \"gh-sync\"\n// gh-sync:keep-end\n}\n";
+        let input = b"{\n// graft:keep-start\n\"name\": \"my-project\"\n// graft:keep-end\n}\n";
         let (stripped, blocks) = strip_marker_blocks(input).unwrap();
         assert_eq!(stripped, b"{\n}\n");
         assert_eq!(blocks.len(), 1);

--- a/crates/graft-engine/src/strategy/patch.rs
+++ b/crates/graft-engine/src/strategy/patch.rs
@@ -47,7 +47,7 @@ pub trait PatchRunner {
 /// `local` to determine whether a write is needed.
 ///
 /// When `preserve_markers` is `true`, marker blocks enclosed by
-/// `gh-sync:keep-start` / `gh-sync:keep-end` comments are stripped from both
+/// `graft:keep-start` / `graft:keep-end` comments are stripped from both
 /// `upstream` and `local` before the patch is applied and before drift
 /// comparison, so marker content is excluded from drift detection.
 /// When the patched result is written back, the marker blocks to re-insert
@@ -252,12 +252,12 @@ mod tests {
     fn preserve_markers_upstream_markers_propagated_when_local_none() {
         // upstream has a marker block; patched result has none; local is None.
         // Expected: Changed with upstream markers inserted into the patched output.
-        let upstream = b"a = 1\n# gh-sync:keep-start\nb = upstream\n# gh-sync:keep-end\n";
+        let upstream = b"a = 1\n# graft:keep-start\nb = upstream\n# graft:keep-end\n";
         // strip upstream markers before patching (mirrors the real behaviour)
         let patched_content = b"a = 1\n".to_vec();
         let runner = MockPatchRunner::success(patched_content);
         let result = apply(upstream, None, Path::new("x.patch"), &runner, true);
-        let expected = b"a = 1\n# gh-sync:keep-start\nb = upstream\n# gh-sync:keep-end\n";
+        let expected = b"a = 1\n# graft:keep-start\nb = upstream\n# graft:keep-end\n";
         assert!(
             matches!(result, StrategyResult::Changed { ref content } if content.as_slice() == expected),
             "expected Changed with upstream markers propagated: {result:?}"
@@ -268,12 +268,12 @@ mod tests {
     fn preserve_markers_upstream_markers_propagated_when_local_has_no_markers() {
         // upstream has markers; local has no markers; patched == stripped local.
         // Expected: Changed because marker blocks need to be inserted.
-        let upstream = b"a = 1\n# gh-sync:keep-start\nb = upstream\n# gh-sync:keep-end\n";
+        let upstream = b"a = 1\n# graft:keep-start\nb = upstream\n# graft:keep-end\n";
         let local = b"a = 1\n";
         // patched equals local stripped (no diff outside markers)
         let runner = MockPatchRunner::success(b"a = 1\n".to_vec());
         let result = apply(upstream, Some(local), Path::new("x.patch"), &runner, true);
-        let expected = b"a = 1\n# gh-sync:keep-start\nb = upstream\n# gh-sync:keep-end\n";
+        let expected = b"a = 1\n# graft:keep-start\nb = upstream\n# graft:keep-end\n";
         assert!(
             matches!(result, StrategyResult::Changed { ref content } if content.as_slice() == expected),
             "expected Changed with upstream markers inserted: {result:?}"

--- a/crates/graft-engine/src/strategy/replace.rs
+++ b/crates/graft-engine/src/strategy/replace.rs
@@ -85,7 +85,7 @@ mod tests {
     fn apply_with_markers_local_blocks_preserved_when_upstream_changed() {
         // Arrange: upstream has no markers; local wraps a value in a marker block.
         let upstream = b"a = upstream\n";
-        let local = b"a = upstream\n# gh-sync:keep-start\nb = local\n# gh-sync:keep-end\n";
+        let local = b"a = upstream\n# graft:keep-start\nb = local\n# graft:keep-end\n";
         // After strip(upstream) = "a = upstream\n"; local blocks = the b=local block.
         // merged = "a = upstream\n" + block → same as local → Unchanged.
         let result = apply_with_markers(upstream, Some(local));
@@ -98,7 +98,7 @@ mod tests {
     #[test]
     fn apply_with_markers_changed_when_non_marker_differs() {
         let upstream = b"a = new\n";
-        let marker_block = b"# gh-sync:keep-start\nb = local\n# gh-sync:keep-end\n";
+        let marker_block = b"# graft:keep-start\nb = local\n# graft:keep-end\n";
         let local = [b"a = old\n".as_slice(), marker_block.as_slice()].concat();
         let result = apply_with_markers(upstream, Some(&local));
         // expected content = upstream + marker block
@@ -124,7 +124,7 @@ mod tests {
     #[test]
     fn apply_with_markers_unbalanced_local_returns_error() {
         let upstream = b"a = 1\n";
-        let local = b"# gh-sync:keep-start\na = 1\n"; // missing keep-end
+        let local = b"# graft:keep-start\na = 1\n"; // missing keep-end
         let result = apply_with_markers(upstream, Some(local));
         assert!(
             matches!(result, StrategyResult::Error(ref msg) if msg.contains("local")),
@@ -136,7 +136,7 @@ mod tests {
     fn apply_with_markers_upstream_markers_propagated_when_local_none() {
         // upstream has a marker block; local is None (first sync).
         // Expected: upstream marker block is preserved in the output.
-        let upstream = b"a = 1\n# gh-sync:keep-start\nb = upstream\n# gh-sync:keep-end\n";
+        let upstream = b"a = 1\n# graft:keep-start\nb = upstream\n# graft:keep-end\n";
         let result = apply_with_markers(upstream, None);
         assert!(
             matches!(result, StrategyResult::Changed { ref content } if content == upstream),
@@ -148,7 +148,7 @@ mod tests {
     fn apply_with_markers_upstream_markers_propagated_when_local_has_no_markers() {
         // upstream has a marker block; local has the upstream content but no markers.
         // Expected: Changed with upstream markers inserted.
-        let upstream = b"a = 1\n# gh-sync:keep-start\nb = upstream\n# gh-sync:keep-end\n";
+        let upstream = b"a = 1\n# graft:keep-start\nb = upstream\n# graft:keep-end\n";
         let local = b"a = 1\n";
         let result = apply_with_markers(upstream, Some(local));
         assert!(
@@ -161,7 +161,7 @@ mod tests {
     fn apply_with_markers_idempotent_after_upstream_marker_propagation() {
         // After the first sync propagates upstream markers to local, a second sync
         // with the same upstream must produce Unchanged.
-        let upstream = b"a = 1\n# gh-sync:keep-start\nb = upstream\n# gh-sync:keep-end\n";
+        let upstream = b"a = 1\n# graft:keep-start\nb = upstream\n# graft:keep-end\n";
         // local now carries the marker block (as it would after the first sync).
         let local = upstream;
         let result = apply_with_markers(upstream, Some(local));
@@ -175,8 +175,8 @@ mod tests {
     fn apply_with_markers_local_markers_take_precedence_over_upstream() {
         // local has its own marker block content that differs from upstream.
         // Expected: local's marker block is preserved (not replaced by upstream).
-        let upstream = b"a = 1\n# gh-sync:keep-start\nb = upstream\n# gh-sync:keep-end\n";
-        let local = b"a = 1\n# gh-sync:keep-start\nb = local_custom\n# gh-sync:keep-end\n";
+        let upstream = b"a = 1\n# graft:keep-start\nb = upstream\n# graft:keep-end\n";
+        let local = b"a = 1\n# graft:keep-start\nb = local_custom\n# graft:keep-end\n";
         let result = apply_with_markers(upstream, Some(local));
         assert!(
             matches!(result, StrategyResult::Unchanged),
@@ -186,7 +186,7 @@ mod tests {
 
     #[test]
     fn apply_with_markers_unbalanced_upstream_returns_error() {
-        let upstream = b"# gh-sync:keep-start\na = 1\n"; // missing keep-end
+        let upstream = b"# graft:keep-start\na = 1\n"; // missing keep-end
         let local = b"a = 1\n";
         let result = apply_with_markers(upstream, Some(local));
         assert!(

--- a/crates/graft-engine/tests/preserve_markers.rs
+++ b/crates/graft-engine/tests/preserve_markers.rs
@@ -43,7 +43,7 @@ fn marker_local_only_block_excluded_from_patch() {
     let dir = tempfile::tempdir().unwrap();
     let upstream_bytes = b"[workspace.dependencies]\nanyhow = \"1.0\"\n";
     // local = upstream content + a marker block; the block is local-only
-    let local_bytes = b"[workspace.dependencies]\nanyhow = \"1.0\"\n# gh-sync:keep-start\ngh-sync-engine = { version = \"0.2.1\" }\n# gh-sync:keep-end\n";
+    let local_bytes = b"[workspace.dependencies]\nanyhow = \"1.0\"\n# graft:keep-start\nmy-crate = { version = \"0.2.1\" }\n# graft:keep-end\n";
     std::fs::write(dir.path().join("Cargo.toml"), local_bytes).unwrap();
     let manifest = make_manifest("Cargo.toml", Some(true));
     let fetcher = MockFetcher::content(upstream_bytes.to_vec());
@@ -86,7 +86,7 @@ fn marker_version_drift_excluded_from_patch() {
     // local = upstream line (outside marker) + drifted line inside marker
     // (synthetic byte-level test; not representable as valid TOML)
     let local_bytes =
-        b"version = \"0.1.0\"\n# gh-sync:keep-start\nversion = \"0.2.1\"\n# gh-sync:keep-end\n";
+        b"version = \"0.1.0\"\n# graft:keep-start\nversion = \"0.2.1\"\n# graft:keep-end\n";
     std::fs::write(dir.path().join("Cargo.toml"), local_bytes).unwrap();
     let manifest = make_manifest("Cargo.toml", Some(true));
     let fetcher = MockFetcher::content(upstream_bytes.to_vec());
@@ -120,9 +120,9 @@ fn marker_external_drift_included_in_patch() {
     // Arrange
     let dir = tempfile::tempdir().unwrap();
     let upstream_bytes =
-        b"# gh-sync:keep-start\nversion = \"0.1.0\"\n# gh-sync:keep-end\nanyhow = \"1.0\"\n";
+        b"# graft:keep-start\nversion = \"0.1.0\"\n# graft:keep-end\nanyhow = \"1.0\"\n";
     let local_bytes =
-        b"# gh-sync:keep-start\nversion = \"0.2.1\"\n# gh-sync:keep-end\nanyhow = \"2.0\"\n";
+        b"# graft:keep-start\nversion = \"0.2.1\"\n# graft:keep-end\nanyhow = \"2.0\"\n";
     std::fs::write(dir.path().join("Cargo.toml"), local_bytes).unwrap();
     let manifest = make_manifest("Cargo.toml", Some(true));
     let fetcher = MockFetcher::content(upstream_bytes.to_vec());
@@ -155,9 +155,9 @@ fn upstream_and_local_both_have_markers_patch_excludes_marker_regions() {
     // Arrange — upstream template has a marker placeholder, local fills it in differently
     let dir = tempfile::tempdir().unwrap();
     let upstream_bytes =
-        b"# gh-sync:keep-start\nmembers = [\"crates/brust\"]\n# gh-sync:keep-end\nanyhow = \"1.0\"\n";
+        b"# graft:keep-start\nmembers = [\"crates/brust\"]\n# graft:keep-end\nanyhow = \"1.0\"\n";
     let local_bytes =
-        b"# gh-sync:keep-start\nmembers = [\"crates/gh-sync\"]\n# gh-sync:keep-end\nanyhow = \"1.0\"\n";
+        b"# graft:keep-start\nmembers = [\"crates/downstream\"]\n# graft:keep-end\nanyhow = \"1.0\"\n";
     std::fs::write(dir.path().join("Cargo.toml"), local_bytes).unwrap();
     let manifest = make_manifest("Cargo.toml", Some(true));
     let fetcher = MockFetcher::content(upstream_bytes.to_vec());
@@ -186,9 +186,9 @@ fn upstream_and_local_markers_with_external_drift_patch_non_empty() {
     // Arrange
     let dir = tempfile::tempdir().unwrap();
     let upstream_bytes =
-        b"# gh-sync:keep-start\nmembers = [\"crates/brust\"]\n# gh-sync:keep-end\nanyhow = \"1.0\"\n";
+        b"# graft:keep-start\nmembers = [\"crates/brust\"]\n# graft:keep-end\nanyhow = \"1.0\"\n";
     let local_bytes =
-        b"# gh-sync:keep-start\nmembers = [\"crates/gh-sync\"]\n# gh-sync:keep-end\nanyhow = \"2.0\"\n";
+        b"# graft:keep-start\nmembers = [\"crates/downstream\"]\n# graft:keep-end\nanyhow = \"2.0\"\n";
     std::fs::write(dir.path().join("Cargo.toml"), local_bytes).unwrap();
     let manifest = make_manifest("Cargo.toml", Some(true));
     let fetcher = MockFetcher::content(upstream_bytes.to_vec());
@@ -223,7 +223,7 @@ fn upstream_and_local_markers_with_external_drift_patch_non_empty() {
 fn upstream_orphan_marker_fails() {
     // Arrange
     let dir = tempfile::tempdir().unwrap();
-    let upstream_bytes = b"# gh-sync:keep-start\nmembers = [\"crates/brust\"]\n";
+    let upstream_bytes = b"# graft:keep-start\nmembers = [\"crates/brust\"]\n";
     let local_bytes = b"anyhow = \"1.0\"\n";
     std::fs::write(dir.path().join("Cargo.toml"), local_bytes).unwrap();
     let manifest = make_manifest("Cargo.toml", Some(true));
@@ -250,7 +250,7 @@ fn upstream_orphan_marker_fails() {
 fn orphan_start_marker_fails_with_unbalanced() {
     // Arrange
     let dir = tempfile::tempdir().unwrap();
-    let local_bytes = b"anyhow = \"1.0\"\n# gh-sync:keep-start\nversion = \"0.2.1\"\n";
+    let local_bytes = b"anyhow = \"1.0\"\n# graft:keep-start\nversion = \"0.2.1\"\n";
     std::fs::write(dir.path().join("Cargo.toml"), local_bytes).unwrap();
     let manifest = make_manifest("Cargo.toml", Some(true));
     let fetcher = MockFetcher::content(b"anyhow = \"1.0\"\n".to_vec());
@@ -276,7 +276,8 @@ fn orphan_start_marker_fails_with_unbalanced() {
 fn nested_start_marker_fails_with_nested() {
     // Arrange
     let dir = tempfile::tempdir().unwrap();
-    let local_bytes = b"# gh-sync:keep-start\n# gh-sync:keep-start\ninner\n# gh-sync:keep-end\n# gh-sync:keep-end\n";
+    let local_bytes =
+        b"# graft:keep-start\n# graft:keep-start\ninner\n# graft:keep-end\n# graft:keep-end\n";
     std::fs::write(dir.path().join("Cargo.toml"), local_bytes).unwrap();
     let manifest = make_manifest("Cargo.toml", Some(true));
     let fetcher = MockFetcher::content(b"anyhow = \"1.0\"\n".to_vec());
@@ -304,7 +305,7 @@ fn preserve_markers_false_includes_marker_lines_in_patch() {
     // Arrange
     let dir = tempfile::tempdir().unwrap();
     let upstream_bytes = b"anyhow = \"1.0\"\n";
-    let local_bytes = b"# gh-sync:keep-start\nanyhow = \"1.0\"\n# gh-sync:keep-end\n";
+    let local_bytes = b"# graft:keep-start\nanyhow = \"1.0\"\n# graft:keep-end\n";
     std::fs::write(dir.path().join("Cargo.toml"), local_bytes).unwrap();
     let manifest = make_manifest("Cargo.toml", Some(false));
     let fetcher = MockFetcher::content(upstream_bytes.to_vec());

--- a/crates/graft-manifest/src/manifest.rs
+++ b/crates/graft-manifest/src/manifest.rs
@@ -396,7 +396,7 @@ pub struct Rule {
     /// Explicit patch file path (`patch` strategy only; defaults to convention).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub patch: Option<String>,
-    /// When `true`, lines enclosed by `gh-sync:keep-start` / `gh-sync:keep-end`
+    /// When `true`, lines enclosed by `graft:keep-start` / `graft:keep-end`
     /// marker comments are excluded from drift detection and preserved on write-back.
     /// Valid with `strategy: patch` or `strategy: replace`.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/graft/src/init/schema.rs
+++ b/crates/graft/src/init/schema.rs
@@ -335,7 +335,7 @@ pub const SCHEMA_JSON: &str = r#"{
           },
           "preserve_markers": {
             "type": "boolean",
-            "description": "Preserve gh-sync:keep-start/keep-end marker blocks from the local file. Only used when strategy is 'patch' or 'replace'."
+            "description": "Preserve graft:keep-start/keep-end marker blocks from the local file. Only used when strategy is 'patch' or 'replace'."
           }
         }
       }

--- a/crates/graft/src/init/skill.rs
+++ b/crates/graft/src/init/skill.rs
@@ -33,24 +33,24 @@ from being overwritten during template sync.
 
 ## Marker Syntax
 
-Enclose downstream-specific lines between `gh-sync:keep-start` and
-`gh-sync:keep-end` tokens. The comment character (`#`, `//`, etc.) is
+Enclose downstream-specific lines between `graft:keep-start` and
+`graft:keep-end` tokens. The comment character (`#`, `//`, etc.) is
 irrelevant — only the token presence in the line is checked.
 
 TOML / YAML / shell (`#` comment style):
 
 ```toml
-# gh-sync:keep-start
+# graft:keep-start
 version = \"0.3.0\"
-# gh-sync:keep-end
+# graft:keep-end
 ```
 
 JSON / JSONC (`//` comment style):
 
 ```jsonc
-// gh-sync:keep-start
+// graft:keep-start
 \"name\": \"my-downstream-project\"
-// gh-sync:keep-end
+// graft:keep-end
 ```
 
 ## Enabling in the Manifest
@@ -94,28 +94,28 @@ top of the upstream content.
 
 ```toml
 [workspace.package]
-# gh-sync:keep-start
+# graft:keep-start
 version = \"0.2.1\"
-# gh-sync:keep-end
+# graft:keep-end
 ```
 
 ### mise.toml — environment variable overrides
 
 ```toml
 [env]
-# gh-sync:keep-start
+# graft:keep-start
 RUST_LOG = \"warn,graft=trace\"
-# gh-sync:keep-end
+# graft:keep-end
 ```
 
 ### .vscode/launch.json — project-specific launch configuration
 
 ```jsonc
 {
-  // gh-sync:keep-start
+  // graft:keep-start
   \"name\": \"my-binary\",
   \"cargo\": { \"args\": [\"build\", \"--bin\", \"my-binary\"] }
-  // gh-sync:keep-end
+  // graft:keep-end
 }
 ```
 
@@ -154,11 +154,8 @@ mod tests {
     #[test]
     fn render_contains_marker_tokens() {
         let out = render();
-        assert!(
-            out.contains("gh-sync:keep-start"),
-            "missing keep-start token"
-        );
-        assert!(out.contains("gh-sync:keep-end"), "missing keep-end token");
+        assert!(out.contains("graft:keep-start"), "missing keep-start token");
+        assert!(out.contains("graft:keep-end"), "missing keep-end token");
     }
 
     #[test]
@@ -174,11 +171,11 @@ mod tests {
     fn render_contains_both_comment_styles() {
         let out = render();
         assert!(
-            out.contains("# gh-sync:keep-start"),
+            out.contains("# graft:keep-start"),
             "missing # comment style"
         );
         assert!(
-            out.contains("// gh-sync:keep-start"),
+            out.contains("// graft:keep-start"),
             "missing // comment style"
         );
     }


### PR DESCRIPTION
## Summary

- テスト・doc comment・テンプレート・設定ファイル内の全マーカートークンを `gh-sync:keep-start` / `gh-sync:keep-end` から `graft:keep-start` / `graft:keep-end` に移行
- `markers.rs` の `LEGACY_MARKER_START` / `LEGACY_MARKER_END` 定数と専用の後方互換テスト2件は意図的に保持
- `preserve_markers.rs` のテストデータ名 (`gh-sync-engine`, `crates/gh-sync`) を中立的な名前 (`my-crate`, `crates/downstream`) にリネーム

## Test plan

- [ ] `mise run test` — 全テスト pass を確認
- [ ] `mise run pre-commit` — clippy, fmt, ast-grep, lint 全て pass を確認
- [ ] `grep -rn "gh-sync:keep" --include="*.rs" --include="*.json"` で残存箇所が LEGACY 定数・互換テストのみであることを確認