### PR TITLE
fix(cli): enforce conflicts_with_all for --yes and --patch-refresh flags

### DIFF
--- a/crates/graft/src/sync/cli.rs
+++ b/crates/graft/src/sync/cli.rs
@@ -58,11 +58,11 @@ pub struct SyncFileArgs {
     pub ci_check: bool,
 
     /// Re-generate patch files from the current upstream diff
-    #[arg(long = "patch-refresh", conflicts_with_all = ["validate", "ci_check"])]
+    #[arg(long = "patch-refresh", conflicts_with_all = ["validate", "ci_check", "dry_run"])]
     pub patch_refresh: bool,
 
     /// Apply changes without prompting for confirmation
-    #[arg(short = 'y', long = "yes", conflicts_with = "dry_run")]
+    #[arg(short = 'y', long = "yes", conflicts_with_all = ["dry_run", "validate", "ci_check", "patch_refresh"])]
     pub yes: bool,
 }
 
@@ -100,6 +100,6 @@ pub struct SyncRepoArgs {
     pub ci_check: bool,
 
     /// Apply changes without prompting for confirmation
-    #[arg(short = 'y', long = "yes", conflicts_with = "dry_run")]
+    #[arg(short = 'y', long = "yes", conflicts_with_all = ["dry_run", "ci_check"])]
     pub yes: bool,
 }

--- a/docs/specs/graft/cli.ja.md
+++ b/docs/specs/graft/cli.ja.md
@@ -15,21 +15,30 @@ Commands:
 
 ## 2. `graft sync` フラグ
 
-| フラグ            | 短縮 | 型   | デフォルト                  | 説明                                           |
-| ----------------- | ---- | ---- | --------------------------- | ---------------------------------------------- |
-| `--manifest`      | `-m` | Path | `.github/graft/config.yaml` | マニフェストパス                               |
-| `--dry-run`       | `-n` | bool | false                       | プレビューのみ(diff 出力、ファイル変更なし)    |
-| `--validate`      |      | bool | false                       | マニフェストバリデーションのみ                 |
-| `--ci-check`      |      | bool | false                       | drift detection                                |
-| `--patch-refresh` |      | bool | false                       | patch ファイルを upstream との diff で自動生成 |
+| フラグ                | 短縮 | 型   | デフォルト                  | 説明                                                   |
+| --------------------- | ---- | ---- | --------------------------- | ------------------------------------------------------ |
+| `--manifest`          | `-m` | Path | `.github/graft/config.yaml` | マニフェストパス                                       |
+| `--upstream-manifest` |      | str  | —                           | upstream マニフェスト参照 (`owner/repo@ref:path` 形式) |
+| `--dry-run`           | `-n` | bool | false                       | プレビューのみ(diff 出力、ファイル変更なし)            |
+| `--validate`          |      | bool | false                       | マニフェストバリデーションのみ                         |
+| `--ci-check`          |      | bool | false                       | drift detection                                        |
+| `--patch-refresh`     |      | bool | false                       | patch ファイルを upstream との diff で自動生成         |
+| `--yes`               | `-y` | bool | false                       | 確認プロンプトをスキップして変更を適用                 |
 
 `gh` CLI が `GITHUB_TOKEN` 環境変数を自動的に使用する。
 commit / PR 操作はこのコマンドでは行わない — skill 経由で Claude に委ねる。
 
 ## 3. フラグの競合ルール
 
+### `sync file`
+
 - `--validate`, `--ci-check`, `--patch-refresh` は相互排他
-- `--dry-run` は sync モード(デフォルト)のみ有効。他のモードでは無視する
+- `--dry-run` は `--patch-refresh` および `--yes` と競合
+- `--yes` は `--dry-run`, `--validate`, `--ci-check`, `--patch-refresh` と競合
+
+### `sync repo`
+
+- `--yes` は `--dry-run`, `--ci-check` と競合
 
 ## 4. `graft init` フラグ
 


### PR DESCRIPTION
## Summary

- `--yes` がread-onlyモードフラグ (`--validate`, `--ci-check`, `--patch-refresh`) と組み合わせた場合に clap に無視されるバグを修正
- `--dry-run` が `--patch-refresh` と組み合わせた場合に無視されるバグを修正 (patch ファイルは書き込まれる)
- `conflicts_with_all` 宣言を追加し、不正な組み合わせを parse 時にエラーとして拒否するよう変更

## 影響範囲

| 構造体 | フラグ | 追加した競合フラグ |
|---|---|---|
| `SyncFileArgs` | `--yes` | `validate`, `ci_check`, `patch_refresh` |
| `SyncFileArgs` | `--patch-refresh` | `dry_run` |
| `SyncRepoArgs` | `--yes` | `ci_check` |

## Test plan

- [ ] `graft sync file --yes --validate` → exit 2 (clap error)
- [ ] `graft sync file --yes --ci-check` → exit 2 (clap error)
- [ ] `graft sync file --yes --patch-refresh` → exit 2 (clap error)
- [ ] `graft sync file --dry-run --patch-refresh` → exit 2 (clap error)
- [ ] `graft sync repo --yes --ci-check` → exit 2 (clap error)
- [ ] `graft sync file --yes` 単独 → 正常動作
- [ ] 587 tests pass